### PR TITLE
- NAT Support / VNET cleanup

### DIFF
--- a/dnsmasq.json
+++ b/dnsmasq.json
@@ -19,5 +19,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/homebridge.json
+++ b/homebridge.json
@@ -3,7 +3,7 @@
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/grimneko/iocage-plugin-homebridge.git",
     "properties": {
-        "vnet": 1
+        "nat": 1
     },
     "pkgs": [
         "python",

--- a/irssi.json
+++ b/irssi.json
@@ -3,6 +3,9 @@
     "plugin_schema": "2",
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-irssi.git",
+    "properties": {
+        "nat": 1
+    },
     "pkgs": [
         "irssi"
     ],
@@ -15,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/madsonic.json
+++ b/madsonic.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/openvpn.json
+++ b/openvpn.json
@@ -8,7 +8,7 @@
     ],
     "properties": {
         "allow_raw_sockets": 1,
-        "vnet": 1,
+        "dhcp": 1,
         "allow_tun": 1
     },
     "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/latest",
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/rtorrent-flood.json
+++ b/rtorrent-flood.json
@@ -12,7 +12,8 @@
     ],
     "properties": {
         "allow_raw_sockets": 1,
-        "allow_tun": 1
+        "allow_tun": 1,
+        "nat": 1
     },
     "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/quarterly",
     "fingerprints": {
@@ -23,5 +24,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/sickchill.json
+++ b/sickchill.json
@@ -20,5 +20,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/unificontroller-lts.json
+++ b/unificontroller-lts.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": false
+    "official": false,
+    "revision": "0"
 }

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -18,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/weechat.json
+++ b/weechat.json
@@ -3,6 +3,9 @@
     "plugin_schema": "2",
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-weechat.git",
+    "properties": {
+        "nat": 1
+    },
     "pkgs": [
         "weechat"
     ],
@@ -15,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }

--- a/xmrig.json
+++ b/xmrig.json
@@ -3,6 +3,9 @@
     "plugin_schema": "2",
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-xmrig.git",
+    "properties": {
+        "nat": 1
+    },
     "pkgs": [
         "xmrig"
     ],
@@ -15,5 +18,6 @@
             }
         ]
     },
-    "official": true
+    "official": true,
+    "revision": "0"
 }


### PR DESCRIPTION
- Set dhcp for openvpn needs to be access directly
- Added missing revision to plugins which didt had it
- NAT support for the rest

Signed-off-by: Martin Wilke <miwi@ixsystems.com>