### PR TITLE
Change GitHub artifact location

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -142,9 +142,17 @@
     "sabnzbd": {
         "MANIFEST": "sabnzbd.json",
         "name": "Sabnzbd",
-        "icon": "https://raw.githubusercontent.com/RogerAirgood/iocage-plugin-index/master/icons/sabnzbd.png",
+        "icon": "https://raw.githubusercontent.com/ix-plugin-hub/iocage-plugin-index/master/icons/sabnzbd.png",
         "description": "Sabznbd is a newsgroup reader.",
         "official": false,
         "primary_pkg": "sabnzbdplus"
+    },
+    "privatebin": {
+        "MANIFEST": "privatebin.json",
+        "name": "PrivateBin",
+        "icon": "https://privatebin.info/img/logo.png",
+        "description": "PrivateBin is a minimalist, open source online pastebin where the server has zero knowledge of pasted data.",
+        "official": false,
+        "primary_pkg": "privatebin"
     }
 }

--- a/privatebin.json
+++ b/privatebin.json
@@ -1,0 +1,26 @@
+{
+    "name": "PrivateBin",
+    "plugin_schema": "2",
+    "release": "11.3-RELEASE",
+    "artifact": "https://github.com/ConorBeh/iocage-plugin-privatebin.git",
+    "pkgs": [
+        "privatebin"
+        "lighttpd",
+        "ca_root_nss",
+        "openssl"
+    ],
+    "properties": {
+        "dhcp": 1
+    },
+    "packagesite": "http://pkg.FreeBSD.org/FreeBSD:11:amd64/latest",
+    "fingerprints": {
+        "plugin-default": [
+            {
+                "function": "sha256",
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+            }
+        ]
+    },
+    "official": false,
+    "revision": "0"
+}

--- a/privatebin.json
+++ b/privatebin.json
@@ -4,7 +4,7 @@
     "release": "11.3-RELEASE",
     "artifact": "https://github.com/ConorBeh/iocage-plugin-privatebin.git",
     "pkgs": [
-        "privatebin"
+        "privatebin",
         "lighttpd",
         "ca_root_nss",
         "openssl"

--- a/sabnzbd.json
+++ b/sabnzbd.json
@@ -1,7 +1,7 @@
 {
     "name": "sabnzbd",
     "release": "11.3-RELEASE",
-    "artifact": "https://github.com/RogerAirgood/iocage-plugin-sabnzbd.git",
+    "artifact": "https://github.com/ConorBeh/iocage-plugin-sabnzbd.git",
     "properties": {
         "nat": 1,
         "nat_forwards": "tcp(8080:8080)"


### PR DESCRIPTION
I changed my username to ConorBeh(my real name) and have updated the artifact location. I admittedly suck at using Git so this also contains an addition of PrivateBin. Sorry about the wacky PR's. 

You will notice that the server uses a self-signed SSL certificate. I discovered (with the help of Dan Langile) that PrivateBin cannot be accessed via Chrome/Chromium unless SSL is enabled. For this purpose I generated a junk self signed certificate that will expire in 10 years. I'm sure there are better methods for accomplishing this but this seems to work perfectly fine and thankfully lighttpd makes it easy to enable SSL. 