### PR TITLE
about the name

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -52,7 +52,7 @@
     "MANIFEST": "homeassistant.json",
     "description": "Open source home automation that puts local control and privacy first.",
     "icon": "https://icons.freenas.org/community-icons/homeassistant.png",
-    "name": "Home Assistant",
+    "name": "Home Assistant Core",
     "official": false
   },
   "homebridge": {


### PR DESCRIPTION
The Home Assistant plugin uses a Python Virtualenv.
The name displayed in the FreeNAS webui should be changed to "Home Assistant Core".

From the blog post:  Changing the Home Assistant Brand
https://www.home-assistant.io/blog/2020/01/29/changing-the-home-assistant-brand/

>    ... If you run Home Assistant today in a Docker container or run it inside a Python
>    virtual environment, you are running “Home Assistant Core”. Home Assistant Core
>    will forever remain a standalone application like it is today. We promise.
> 
>    This name change is a huge thing! Not just a big thing we all need to get used to,
>    but even bigger for everything that needs to be renamed! ...
