### PR TITLE
Add bash pkg to Gitea

### DIFF
--- a/gitea.json
+++ b/gitea.json
@@ -6,7 +6,8 @@
     "pkgs": [
         "gitea",
         "postgresql11-server",
-        "postgresql11-contrib"
+        "postgresql11-contrib",
+        "bash"
     ],
     "properties": {
         "dhcp": 1


### PR DESCRIPTION
Fixes https://github.com/ConorBeh/iocage-plugin-gitea/issues/1

Bash is needed for pushing to an existing repo