### PR TITLE
use quarterly packagesite

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -35,7 +35,7 @@
   "esphome": {
     "MANIFEST": "esphome.json",
     "name": "ESPHome",
-    "icon": "https://raw.githubusercontent.com/tprelog/freenas-plugin-index/11.3-RELEASE/icons/esphome.png",
+    "icon": "https://icons.freenas.org/community-icons/esphome.png",
     "primary_pkg": null,
     "description": "ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.",
     "official": false

--- a/INDEX
+++ b/INDEX
@@ -61,6 +61,7 @@
     "description": "Open source home automation that puts local control and privacy first.",
     "icon": "https://icons.freenas.org/community-icons/homeassistant.png",
     "name": "Home Assistant Core",
+    "primary_pkg": null,
     "official": false
   },
   "homebridge": {
@@ -163,6 +164,7 @@
     "description": "Website to manage devices flashed with Tasmota.",
     "icon": "https://icons.freenas.org/community-icons/tasmoadmin.png",
     "name": "TasmoAdmin",
+    "primary_pkg": null,
     "official": false
   },
   "unificontroller": {

--- a/INDEX
+++ b/INDEX
@@ -33,12 +33,12 @@
     "category": "backup"
   },
   "esphome": {
-        "MANIFEST": "esphome.json",
-        "name": "ESPHome",
-        "icon": "https://raw.githubusercontent.com/tprelog/freenas-plugin-index/11.3-RELEASE/icons/esphome.png",
-        "primary_pkg": null,
-        "description": "ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.",
-        "official": false
+    "MANIFEST": "esphome.json",
+    "name": "ESPHome",
+    "icon": "https://raw.githubusercontent.com/tprelog/freenas-plugin-index/11.3-RELEASE/icons/esphome.png",
+    "primary_pkg": null,
+    "description": "ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.",
+    "official": false
   },
   "gitea": {
     "MANIFEST": "gitea.json",

--- a/mosquitto.json
+++ b/mosquitto.json
@@ -10,7 +10,7 @@
   "pkgs": [
     "mosquitto"
   ],
-  "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+  "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
   "fingerprints": {
     "plugin-default": [
       {

--- a/mosquitto.json
+++ b/mosquitto.json
@@ -4,6 +4,7 @@
   "artifact": "https://github.com/tprelog/iocage-mosquitto.git",
   "official": "false",
   "properties": {
+    "priority": "98",
     "allow_raw_sockets": "1",
     "dhcp": "1"
   },


### PR DESCRIPTION
I've tested switching the packagesite back to quarterly for the mosquitto plugin. Everything seems to working as expected. It is still the same pkg version of mosquitto so I do not expect this change to have any surprise issues.

I've also corrected the indent for esphome and added `primary_pkg: null` to my remaining plugins