### PR TITLE
Add ffmpeg to bazarr.json

### DIFF
--- a/bazarr.json
+++ b/bazarr.json
@@ -9,7 +9,8 @@
     "py37-libxml2",
     "py37-sqlite3",
     "libxslt",
-    "git"
+    "git",
+    "unrar"
   ],
   "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
   "fingerprints": {

--- a/bazarr.json
+++ b/bazarr.json
@@ -10,7 +10,8 @@
     "py37-sqlite3",
     "libxslt",
     "git",
-    "unrar"
+    "unrar",
+    "ffmpeg"
   ],
   "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
   "fingerprints": {


### PR DESCRIPTION
As @josdion wrote in this issue: https://github.com/fulder/iocage-plugin-bazarr/issues/1#issuecomment-616056029 bazarr does have a `ffprobe` dependency, which can be installed using the `ffmpeg` package.

Also add back the prveiously removed and needed unrar package.