### PR TITLE
add openssl

### DIFF
--- a/homeassistant.json
+++ b/homeassistant.json
@@ -16,6 +16,7 @@
     "gmake",
     "libxml2",
     "libxslt",
+    "openssl",
     "pkgconf",
     "python37",
     "py37-av",


### PR DESCRIPTION
The HomeKit integration and possibly others, require openssl-1.1.1