### PR TITLE
Update Madsonic to new plugin version

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -149,7 +149,7 @@
     "icon": "https://icons.freenas.org/community-icons/madsonic.png",
     "name": "MadSonic",
     "official": true,
-    "primary_pkg": "madsonic-standalone"
+    "primary_pkg": null
   },
   "mosquitto": {
     "MANIFEST": "mosquitto.json",

--- a/madsonic.json
+++ b/madsonic.json
@@ -8,7 +8,8 @@
     },
     "pkgs": [
         "openjdk8-jre",
-        "ca_root_nss"
+        "ca_root_nss",
+        "ffmpeg"
     ],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
     "fingerprints": {

--- a/madsonic.json
+++ b/madsonic.json
@@ -7,7 +7,7 @@
         "nat_forwards": "tcp(4040:4040)"
     },
     "pkgs": [
-        "madsonic-standalone"
+        "openjdk8-jre"
     ],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
     "fingerprints": {

--- a/madsonic.json
+++ b/madsonic.json
@@ -1,25 +1,25 @@
 {
-    "name": "MadSonic",
-    "release": "11.3-RELEASE",
-    "artifact": "https://github.com/freenas/iocage-plugin-madsonic.git",
-    "properties": {
-        "nat": 1,
-        "nat_forwards": "tcp(4040:4040)"
-    },
-    "pkgs": [
-        "openjdk8-jre",
-        "ca_root_nss",
-        "ffmpeg"
-    ],
-    "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
-    "fingerprints": {
-        "iocage-plugins": [
-            {
-                "function": "sha256",
-                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
-            }
-        ]
-    },
-    "official": true,
-    "revision": "0"
+  "name": "MadSonic",
+  "release": "11.3-RELEASE",
+  "artifact": "https://github.com/freenas/iocage-plugin-madsonic.git",
+  "properties": {
+    "nat": 1,
+    "nat_forwards": "tcp(4040:4040)"
+  },
+  "pkgs": [
+    "openjdk8-jre",
+    "ca_root_nss",
+    "ffmpeg"
+  ],
+  "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+  "fingerprints": {
+    "iocage-plugins": [
+      {
+        "function": "sha256",
+        "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
+      }
+    ]
+  },
+  "official": true,
+  "revision": "0"
 }

--- a/madsonic.json
+++ b/madsonic.json
@@ -7,7 +7,8 @@
         "nat_forwards": "tcp(4040:4040)"
     },
     "pkgs": [
-        "openjdk8-jre"
+        "openjdk8-jre",
+        "ca_root_nss"
     ],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/11.3-RELEASE",
     "fingerprints": {


### PR DESCRIPTION
Should be merged after: https://github.com/freenas/iocage-plugin-madsonic/pull/1
Related to issue: https://github.com/ix-plugin-hub/iocage-plugin-index/issues/74

* Remove unavailable `madsonic-standalone` package
* Change packagesite mirror from TrueNas to latets FreeBSD
* Install java, CA certs and freebsd needed for the new plugin to work properly