### PR TITLE
use quarterly package site

### DIFF
--- a/homeassistant.json
+++ b/homeassistant.json
@@ -36,7 +36,7 @@
     "wget",
     "zip"
   ],
-  "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+  "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
   "fingerprints": {
     "plugin-default": [
       {


### PR DESCRIPTION
Well I did not see this one coming... `ffmpeg` is missing or has been removed from `FreeBSD:12:amd64/latest` -- I don't know if there is a better solution besides switching to `quarterly`, which still contains `ffmpeg` -- I really do not want to build from ports in a plugin.

I last tested this install on June 30 2020 using `"http://pkg.FreeBSD.org/${ABI}/latest"` and `ffmpeg` was correctly installed.

```
root@ha12-beta1:~ # pkg show ffmpeg
ffmpeg-4.3,1
Name           : ffmpeg
Version        : 4.3,1
Installed on   : Tue Jun 30 10:41:57 2020 EDT
Origin         : multimedia/ffmpeg
Architecture   : FreeBSD:12:amd64
Prefix         : /usr/local
Categories     : net audio multimedia
Licenses       : GPLv3+, LGPL3+
Maintainer     : multimedia@FreeBSD.org
WWW            : http://ffmpeg.org/
Comment        : Realtime audio/video encoder/converter and streaming server
```

Now since ffmpeg has been removed the plugin is failing to install again
```
truenas% sudo iocage fetch -P ./homeassistant.json --name c
Plugin: homeassistant
  Official Plugin: false
  Using RELEASE: 12.1-RELEASE
  Using Branch: 12.1-RELEASE
  Post-install Artifact: https://github.com/tprelog/iocage-homeassistant.git
  These pkgs will be installed:
    - autoconf
    - bash
    - ca_root_nss
    - curl
    - ffmpeg
    - gcc
    - gmake
    - libxml2
    - libxslt
    - pkgconf
    - python38
    - py38-sqlite3
    - sudo
    - wget
    - zip

Testing Host DNS response to pkg.FreeBSD.org
Testing c's SRV response to pkg.FreeBSD.org
Testing c's DNSSEC response to pkg.FreeBSD.org

Installing plugin packages:
  - autoconf... 
  - bash... 
  - ca_root_nss... 
  - curl... 
  - ffmpeg... 
    - ffmpeg failed to install, retry #1
    - ffmpeg failed to install, retry #2
    - ffmpeg failed to install, retry #3
  - gcc... 
    - gcc failed to install, retry #1
    - gcc failed to install, retry #2
    - gcc failed to install, retry #3
  - gmake... 
    - gmake failed to install, retry #1
    - gmake failed to install, retry #2
    - gmake failed to install, retry #3
  - libxml2... 
    - libxml2 failed to install, retry #1
    - libxml2 failed to install, retry #2
    - libxml2 failed to install, retry #3
  - libxslt... 
    - libxslt failed to install, retry #1
    - libxslt failed to install, retry #2
    - libxslt failed to install, retry #3
  - pkgconf... 
    - pkgconf failed to install, retry #1
    - pkgconf failed to install, retry #2
    - pkgconf failed to install, retry #3
  - python38... 
    - python38 failed to install, retry #1
    - python38 failed to install, retry #2
    - python38 failed to install, retry #3
  - py38-sqlite3... 
    - py38-sqlite3 failed to install, retry #1
    - py38-sqlite3 failed to install, retry #2
    - py38-sqlite3 failed to install, retry #3
  - sudo... 
    - sudo failed to install, retry #1
    - sudo failed to install, retry #2
    - sudo failed to install, retry #3
  - wget... 
    - wget failed to install, retry #1
    - wget failed to install, retry #2
    - wget failed to install, retry #3
  - zip... 
    - zip failed to install, retry #1
    - zip failed to install, retry #2
    - zip failed to install, retry #3

pkg error:
  - ffmpeg :,gcc :,gmake :,libxml2 :,libxslt :,pkgconf :,python38 :,py38-sqlite3 :,sudo :,wget :,zip :

Refusing to fetch artifact and run post_install.sh!
c had a failure
Exception: SystemExit Message: 1
Partial plugin destroyed
```

As a further test, I have also gone to back my successful install from June 30 and removed ffmpeg
```
root@ha12-beta1:~ # pkg delete ffmpeg
Checking integrity... done (0 conflicting)
Deinstallation has been requested for the following 1 packages (of 0 packages in the universe):

Installed packages to be REMOVED:
        ffmpeg: 4.3,1

Number of packages to be removed: 1

The operation will free 68 MiB.

Proceed with deinstalling packages? [y/N]: y
[ha12-beta1] [1/1] Deinstalling ffmpeg-4.3,1...
[ha12-beta1] [1/1] Deleting files for ffmpeg-4.3,1: 100%
```

Clearly it has been removed and is no longer available for reinstall from the latest package site
```
root@ha12-beta1:~ # pkg install ffmpeg
Updating plugin-default repository catalogue...
plugin-default repository is up to date.
All repositories are up to date.
pkg: No packages available to install matching 'ffmpeg' have been found in the repositories
```
