### PR TITLE
Add www/chromium dependency for channels-dvr

### DIFF
--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -9,7 +9,8 @@
     "pkgs": [
         "ftp/curl",
         "security/ca_root_nss",
-        "security/sudo"
+        "security/sudo",
+        "www/chromium"
     ],
     "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
     "fingerprints": {

--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -17,7 +17,7 @@
         "iocage-plugins": [
             {
                 "function": "sha256",
-                "fingerprint": "226efd3a126fb86e71d60a37353d17f57af816d1c7ecad0623c21f0bf73eb0c7"
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
             }
         ]
     },

--- a/channels-dvr.json
+++ b/channels-dvr.json
@@ -12,7 +12,7 @@
         "security/sudo",
         "www/chromium"
     ],
-    "packagesite": "http://pkg.cdn.trueos.org/iocage/unstable",
+    "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {
         "iocage-plugins": [
             {


### PR DESCRIPTION
Replacement for https://github.com/freenas/iocage-ix-plugins/pull/166 which didn't get merged due to accidental close.

We have had to guide several users through manual jail connect + package install, so it would be very helpful to have this included by default.