### PR TITLE
Move Tautulli from python2 to python3

### DIFF
--- a/tautulli.json
+++ b/tautulli.json
@@ -8,9 +8,9 @@
         "nat_forwards": "tcp(8181:8181)"
     },
     "pkgs": [
-        "lang/python27",
-        "py27-sqlite3",
-        "py27-openssl",
+        "lang/python",
+        "py37-sqlite3",
+        "py37-openssl",
         "security/ca_root_nss",
         "git"
     ],


### PR DESCRIPTION
Tautulli is broken on TrueNAS CORE-beta.  This is an update to re-apply freenas/iocage-ix-plugins#247 into the community repo.

Let me know if you want me to submit the same against the 12.1-RELEASE branch.


