### PR TITLE
Add libconv requirement to jackett

### DIFF
--- a/jackett.json
+++ b/jackett.json
@@ -4,7 +4,8 @@
   "release": "12.1-RELEASE",
   "artifact": "https://github.com/fulder/iocage-plugin-jackett.git",
   "pkgs": [
-    "jackett"
+    "jackett",
+    "libiconv"
   ],
   "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
   "fingerprints": {


### PR DESCRIPTION
Because of a bug in Jackett update, the freenas (and truenas core) plugin got stuck in a non recoverable state, the plugin was no longer working and it was not possible to update it either.

In order to fix the issue the Jackett plugin need to to be updated in a more manual manner. For the freenas/truenas plugin it simply means updating the plugin (as this will trigger the Jackett package to reinstall to an older version making it possible to update using the UI to the newest version, jumping over the buggy one). Although as the majority of the plugins have now been updated to 12.1 FreeBSD version there was a few new bugs (mono 5 doesn't seem to work) which has been fixed on the same branch. The mono has been manually patched for the plugin to the currently newest 6.8.0 version but in order for it to work there is a new `libconv` dependency added in this PR.

Related forum discussion: https://www.ixsystems.com/community/threads/how-to-manually-upgrade-mono-from-5-10-to-5-20-in-a-freenas-jail.78871/
Related to Jackett issue: https://github.com/Jackett/Jackett/issues/9569
Related to plugin PR (should be merged after this one gets merged): https://github.com/fulder/iocage-plugin-jackett/pull/2

Tested and working use cases:
* Installing a fresh plugin inside a 12.1 jail
* Installing an older version of the plugin inside a 11.3 jail and running an upgrade with `iocage upgrade jackett`
* Upgrading the broken 11.3 jail stuck on the buggy version 