### PR TITLE
switch to python 3.8

### DIFF
--- a/homeassistant.json
+++ b/homeassistant.json
@@ -18,8 +18,8 @@
     "libxml2",
     "libxslt",
     "pkgconf",
-    "python37",
-    "py37-sqlite3",
+    "python38",
+    "py38-sqlite3",
     "sudo",
     "wget",
     "zip"


### PR DESCRIPTION
[python 3.7 will be depreciated in Home Assistant 0.118](https://www.home-assistant.io/blog/#python-37-deprecated)

This change is only needed for the 11.3-RELEASE branch. Other branches are already using python 3.8

---
  
Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
