### PR TITLE
use gcc9

### DIFF
--- a/homeassistant.json
+++ b/homeassistant.json
@@ -13,7 +13,7 @@
     "ca_root_nss",
     "curl",
     "ffmpeg",
-    "gcc",
+    "gcc9",
     "gmake",
     "libxml2",
     "libxslt",


### PR DESCRIPTION
Using gcc and python3.8, PyNaCl setup fails in the 11.3-RELEASE
_This pull request is for the 11.3-RELEASE only_ -- There are no issues using gcc with python 3.8 on TrueNAS Core


```
...
configure: error: in `/tmp/pip-install-y2m6dzke/pynacl/build/temp.freebsd-11.3-RELEASE-p14-amd64-3.8':
configure: error: C compiler cannot create executables
...
ERROR: Could not build wheels for PyNaCl which use PEP 517 and cannot be installed directly
```
PyNaCl setup is successful using gcc9


---

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
