### PR TITLE
update esphome.json

### DIFF
--- a/esphome.json
+++ b/esphome.json
@@ -18,7 +18,7 @@
     "wget",
     "zip"
   ],
-  "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
+  "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
   "fingerprints": {
     "plugin-default": [
       {

--- a/esphome.json
+++ b/esphome.json
@@ -11,12 +11,12 @@
     "autoconf",
     "bash",
     "ca_root_nss",
+    "curl",
     "gcc",
     "gmake",
     "pkgconf",
     "python37",
-    "wget",
-    "zip"
+    "py37-pillow"
   ],
   "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",
   "fingerprints": {


### PR DESCRIPTION
switch to quarterly packagesite
updated pkgs
- add `py37-pillow` - missing dependency for `esphome`
- switch `wget` to `curl` - only used by `post_install.sh`
- remove `zip` - never used

---

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
