### PR TITLE
Update MineOS pkg (NAS-107920 & NAS-107986)

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -11,17 +11,17 @@
         "nat_forwards": "tcp(8443:8443),tcp(25565:25565),tcp(25566:25566),tcp(25567:25567),tcp(25568:25568),tcp(25569:25569),tcp(25570:25570)"
     },
     "pkgs": [
-        "sysutils/py-rdiff-backup",
-        "sysutils/screen",
-        "net/rsync",
-        "devel/gmake",
-        "devel/git-lite",
-        "lang/python3",
-        "www/node10",
-        "www/npm-node10",
-        "java/openjdk8-jre",
-        "ftp/wget",
-        "shells/bash"
+        "py37-rdiff-backup",
+        "screen",
+        "rsync",
+        "gmake",
+        "git-lite",
+        "python37",
+        "node",
+        "npm",
+        "openjdk8-jre",
+        "wget",
+        "bash"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
This updates the packages of the MineOS plugin, as per NAS-107920 & NAS-107986.

This was first submitted to legacy FreeNAS 11.3 plugin repo via freenas/iocage-ix-plugins#253 and freenas/iocage-ix-plugins#254