### PR TITLE
update unifi version to unifi6

### DIFF
--- a/unificontroller.json
+++ b/unificontroller.json
@@ -7,7 +7,7 @@
         "nat_forwards": "tcp(8443:8444),udp(3478:3478),tcp(8080:8080),tcp(6789:6789),udp(10001:10001),udp(1900:1900)"
     },
     "pkgs": [
-        "unifi5"
+        "unifi6"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
This upgrades change the `unifi` (not `unifi-lts`) plugin to `unifi6`.
