### PR TITLE
Update Grafana 6 to Grafana 7

### DIFF
--- a/grafana.json
+++ b/grafana.json
@@ -4,7 +4,7 @@
     "release": "12.1-RELEASE",
     "artifact": "https://github.com/MalteHillmann/iocage-plugin-grafana.git",
     "pkgs": [
-        "grafana6",
+        "grafana7",
         "influxdb",
         "curl"
     ],


### PR DESCRIPTION
Updated Grafana from v6 to v7 which is available in 12.1-RELEASE. 
