### PR TITLE
updated pkgs to php74 to fix issues with the drupal8 pkg.

### DIFF
--- a/drupal8.json
+++ b/drupal8.json
@@ -4,20 +4,19 @@
 	"release": "12.1-RELEASE",
 	"artifact": "https://github.com/SumGuyV5/iocage-plugin-drupal8.git",
 	"pkgs": [
-		"php72-zlib",
+		"php74-zlib",
 		"mysql57-server",
 		"mysql57-client",
-		"php72-mysqli",
-		"php72-pdo_mysql",
-		"php72-curl",
-		"php72-gd",
-		"php72-extensions",
-		"php72",
-		"php72-hash",
+		"php74-mysqli",
+		"php74-pdo_mysql",
+		"php74-curl",
+		"php74-gd",
+		"php74-extensions",
+		"php74",
 		"apache24",
-		"mod_php72",
+		"mod_php74",
 		"drupal8",
-		"drush-php72"
+		"drush-php74"
 	],
 	"properties": {
 		"dhcp": 1


### PR DESCRIPTION
I have update this plugin to use the php74 Packages as php72 is EOL and the drupal8 package has made the switch to php74.

This plugin update is need for all the supported FreeBSD versions 11.3 12.0 12.1 12.2. Do I need to make pull request for each of the separate FreeBSD version branches?

Thank You for Your Time.
