### PR TITLE
Add SickChill missing libxslt pkg needed for pip lxml

### DIFF
--- a/sickchill.json
+++ b/sickchill.json
@@ -13,7 +13,8 @@
         "unrar",
         "ca_root_nss",
         "py37-pillow",
-        "libmediainfo"
+        "libmediainfo",
+        "libxslt"
     ],
     "properties": {
         "nat": 1,


### PR DESCRIPTION
Add missing SickChill pkg making the requirements installation in `post_install.sh` log error messages, see e.g.: https://github.com/ix-plugin-hub/iocage-plugin-index/issues/107#issuecomment-743286926