### PR TITLE
Update emby-server-stable.json

### DIFF
--- a/emby-server-stable.json
+++ b/emby-server-stable.json
@@ -1,6 +1,6 @@
 {
     "name": "emby-server-stable",
-    "release": "12.1-RELEASE",
+    "release": "12.2-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
     "properties": {
         "dhcp": 1,
@@ -9,6 +9,26 @@
     "pkgs": [
         "emby-server",
         "ffmpeg"
+        "mono"
+        "libass"
+        "fontconfig"
+        "freetype2" 
+        "fribidi"
+        "gnutls"
+        "iconv" 
+        "opus" 
+        "sqlite3" 
+        "libtheora"
+        "libva" 
+        "libvpx" 
+        "libvorbis"
+        "webp"
+        "libx264"
+        "x265"
+        "dav1d"
+        "libzvbi"
+        "libraw"
+        "ImageMagick6"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Update to 12.2-RELEASE as that is what Emby is built against now.

Added dependences from: https://emby.media/freebsd-server.html as some functions are limited without the complete list. A symptom is the problems some users had with RAW image files as this plug in lacked the ImageMagic6 pkg.

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
