### PR TITLE
Update motioneye.json on 12.2 Branch to latest FreeBSD Release

### DIFF
--- a/motioneye.json
+++ b/motioneye.json
@@ -1,7 +1,7 @@
 {
     "name": "motioneye",
     "plugin_schema": "2",
-    "release": "11.3-RELEASE",
+    "release": "12.2-RELEASE",
     "artifact": "https://github.com/cilix-lab/iocage-plugin-motioneye.git",
     "official": false,
     "properties": {
@@ -26,5 +26,5 @@
             }
         ]
     },
-    "revision": "0"
+    "revision": "12.2"
 }


### PR DESCRIPTION
Updated to 12.2-RELEASE. Tested with 12.0-RELEASE-U1 with network camera. Webpage works, displays camera feed, detects motion, and captures image sucessfully. This is the update for each TrueNAS Release

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
