### PR TITLE
MineOS updates for 12.2

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -1,6 +1,7 @@
 {
     "name": "mineos",
-    "release": "12.1-RELEASE",
+    "plugin_schema": "2",
+    "release": "12.2-RELEASE",
     "artifact": "https://github.com/jsegaert/iocage-plugin-mineos.git",
     "official": false,
     "properties": {
@@ -19,7 +20,7 @@
         "python37",
         "node",
         "npm",
-        "openjdk8-jre",
+        "openjdk11-jre",
         "wget",
         "bash"
     ],


### PR DESCRIPTION
The PR contains the following updates to the MineOS plugin:

- Update `release` to 12.2-RELEASE as 12.1-RELEASE is EOL on 31-JAN-2021
- Set `plugin_schema` to 2; this was implemented a long time ago, but the manifest was never updated
- Update Java to 11 to support PaperMC servers as per hexparrot/mineos-node#381

Tested on TrueNAS-12.0-U1.  **Please also tag/merge into 12.2-RELEASE branch**

Thank you!