### PR TITLE
update tasmodamin pkgs to php74

### DIFF
--- a/tasmoadmin.json
+++ b/tasmoadmin.json
@@ -10,12 +10,12 @@
   "pkgs": [
     "bash",
     "nginx",
-    "php72",
-    "php72-curl",
-    "php72-filter",
-    "php72-json",
-    "php72-session",
-    "php72-zip",
+    "php74",
+    "php74-curl",
+    "php74-filter",
+    "php74-json",
+    "php74-session",
+    "php74-zip",
     "svnup"
   ],
   "packagesite": "http://pkg.FreeBSD.org/${ABI}/quarterly",


### PR DESCRIPTION
Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size

# Update tasmoadmin to use php74

This update should be merged to all 12.x releases ASAP to resolve https://github.com/ix-plugin-hub/iocage-plugin-index/issues/155 for users on TrueNAS Core.

This also resolve https://github.com/tprelog/iocage-tasmoadmin/issues/4

I am no longer supporting my plugins on FreeNAS, which uses the expired 11.3-RELEASE.
