### PR TITLE
Cirrus CI tasks for plugin installation tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,3 @@
-freebsd_instance:
-  image_family: freebsd-12-2
-  cpu: 1
-  memory: "1"
-
 install_template: &INSTALL_PLUGIN
   requirements_script: pkg install -y jq
   install_script: |
@@ -89,290 +84,638 @@ install_template: &INSTALL_PLUGIN
 install_backuppc_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('backuppc.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "backuppc.json"
+
 install_bazarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('bazarr.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "bazarr.json"
+
 install_bind_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('bind.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "bind.json"
+
 install_calibre-web_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('calibre-web.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "calibre-web.json"
+
 install_channels-dvr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('channels-dvr.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "channels-dvr.json"
+
 install_clamav_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('clamav.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "clamav.json"
+
 install_deluge-pip_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('deluge-pip.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "deluge-pip.json"
+
 install_dnsmasq_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('dnsmasq.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "dnsmasq.json"
+
 install_drupal8_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('drupal8.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "drupal8.json"
+
 install_duplicati_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('duplicati.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "duplicati.json"
+
 install_emby_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('emby.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "emby.json"
+
 install_emby-server-stable_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('emby-server-stable.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "emby-server-stable.json"
+
 install_esphome_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('esphome.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "esphome.json"
+
 install_famp_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('famp.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "famp.json"
+
 install_gitea_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('gitea.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "gitea.json"
+
 install_gitlab_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('gitlab.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "gitlab.json"
+
 install_gogs_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('gogs.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "gogs.json"
+
 install_grafana_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('grafana.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "grafana.json"
+
 install_heimdall-dashboard_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('heimdall-dashboard.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "heimdall-dashboard.json"
+
 install_homeassistant_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('homeassistant.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "homeassistant.json"
+
 install_homebridge_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('homebridge.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "homebridge.json"
+
 install_hoobs_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('hoobs.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "hoobs.json"
+
 install_i2p_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('i2p.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "i2p.json"
+
 install_irssi_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('irssi.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "irssi.json"
+
 install_jackett_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('jackett.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "jackett.json"
+
 install_jenkins_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('jenkins.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "jenkins.json"
+
 install_jenkins-lts_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('jenkins-lts.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "jenkins-lts.json"
+
 install_lidarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('lidarr.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "lidarr.json"
+
 install_madsonic_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('madsonic.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "madsonic.json"
+
 install_mineos_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('mineos.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "mineos.json"
+
 install_monica_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('monica.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "monica.json"
+
 install_mosquitto_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('mosquitto.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "mosquitto.json"
+
 install_motioneye_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('motioneye.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "motioneye.json"
+
 install_netdata_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('netdata.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "netdata.json"
+
 install_node-red_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('node-red.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "node-red.json"
+
 install_nzbget_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('nzbget.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "nzbget.json"
+
 install_openspeedtest-server_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('openspeedtest-server.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "openspeedtest-server.json"
+
 install_openvpn_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('openvpn.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "openvpn.json"
+
 install_privatebin_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('privatebin.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "privatebin.json"
+
 install_qbittorrent_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('qbittorrent.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "qbittorrent.json"
+
 install_quasselcore_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('quasselcore.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "quasselcore.json"
+
 install_radarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('radarr.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "radarr.json"
+
 install_rslsync_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('rslsync.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "rslsync.json"
+
 install_rtorrent-flood_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('rtorrent-flood.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "rtorrent-flood.json"
+
 install_sabnzbd_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('sabnzbd.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "sabnzbd.json"
+
 install_sickchill_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('sickchill.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "sickchill.json"
+
 install_sonarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('sonarr.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "sonarr.json"
+
 install_tasmoadmin_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('tasmoadmin.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "tasmoadmin.json"
+
 install_tautulli_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('tautulli.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "tautulli.json"
+
 install_transmission_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('transmission.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "transmission.json"
+
 install_unificontroller_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('unificontroller.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "unificontroller.json"
+
 install_unificontroller-lts_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('unificontroller-lts.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "unificontroller-lts.json"
+
 install_vault_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('vault.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "vault.json"
+
 install_weechat_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('weechat.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "weechat.json"
+
 install_xmrig_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('xmrig.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "xmrig.json"
+
 install_zoneminder_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('zoneminder.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "zoneminder.json"
+
 install_zrepl_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('zrepl.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "zrepl.json"
+
 install_zwavejs2mqtt_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('zwavejs2mqtt.json')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "zwavejs2mqtt.json"
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -365,7 +365,7 @@ mosquitto_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "mosquitto.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -389,7 +389,7 @@ node-red_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "node-red.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,6 +56,15 @@ install_template: &INSTALL_PLUGIN
       done
     done
 
+    if [ "$kmods" != "null" ]
+    then
+      echo $kmods | jq -r  '.[]' | while IFS='' read kmod
+      do
+        echo "Loading kmod: ${kmod}"
+        kldload -nv ${kmod}
+      done
+    fi
+
     if [ "$(which git)" = "" ]
     then
       pkg install -y git-lite || pkg install -y git

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,7 +99,7 @@ bazarr_task:
   only_if: "changesInclude('bazarr.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "bazarr.json"
 
@@ -108,7 +108,7 @@ bind_task:
   only_if: "changesInclude('bind.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "bind.json"
 
@@ -117,7 +117,7 @@ calibre-web_task:
   only_if: "changesInclude('calibre-web.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "calibre-web.json"
 
@@ -126,7 +126,7 @@ channels-dvr_task:
   only_if: "changesInclude('channels-dvr.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "channels-dvr.json"
 
@@ -135,7 +135,7 @@ clamav_task:
   only_if: "changesInclude('clamav.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "clamav.json"
 
@@ -144,7 +144,7 @@ deluge-pip_task:
   only_if: "changesInclude('deluge-pip.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "deluge-pip.json"
 
@@ -153,7 +153,7 @@ dnsmasq_task:
   only_if: "changesInclude('dnsmasq.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "dnsmasq.json"
 
@@ -162,7 +162,7 @@ drupal8_task:
   only_if: "changesInclude('drupal8.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "drupal8.json"
 
@@ -171,7 +171,7 @@ duplicati_task:
   only_if: "changesInclude('duplicati.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "duplicati.json"
 
@@ -180,7 +180,7 @@ emby_task:
   only_if: "changesInclude('emby.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "emby.json"
 
@@ -198,7 +198,7 @@ esphome_task:
   only_if: "changesInclude('esphome.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "esphome.json"
 
@@ -207,7 +207,7 @@ famp_task:
   only_if: "changesInclude('famp.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "famp.json"
 
@@ -216,7 +216,7 @@ gitea_task:
   only_if: "changesInclude('gitea.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "gitea.json"
 
@@ -225,7 +225,7 @@ gitlab_task:
   only_if: "changesInclude('gitlab.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "gitlab.json"
 
@@ -234,7 +234,7 @@ gogs_task:
   only_if: "changesInclude('gogs.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "gogs.json"
 
@@ -243,7 +243,7 @@ grafana_task:
   only_if: "changesInclude('grafana.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "grafana.json"
 
@@ -252,7 +252,7 @@ heimdall-dashboard_task:
   only_if: "changesInclude('heimdall-dashboard.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "heimdall-dashboard.json"
 
@@ -261,7 +261,7 @@ homeassistant_task:
   only_if: "changesInclude('homeassistant.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "homeassistant.json"
 
@@ -270,7 +270,7 @@ homebridge_task:
   only_if: "changesInclude('homebridge.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "homebridge.json"
 
@@ -279,7 +279,7 @@ hoobs_task:
   only_if: "changesInclude('hoobs.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "hoobs.json"
 
@@ -288,7 +288,7 @@ i2p_task:
   only_if: "changesInclude('i2p.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "i2p.json"
 
@@ -297,7 +297,7 @@ irssi_task:
   only_if: "changesInclude('irssi.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "irssi.json"
 
@@ -306,7 +306,7 @@ jackett_task:
   only_if: "changesInclude('jackett.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "jackett.json"
 
@@ -315,7 +315,7 @@ jenkins_task:
   only_if: "changesInclude('jenkins.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "jenkins.json"
 
@@ -324,7 +324,7 @@ jenkins-lts_task:
   only_if: "changesInclude('jenkins-lts.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "jenkins-lts.json"
 
@@ -333,7 +333,7 @@ lidarr_task:
   only_if: "changesInclude('lidarr.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "lidarr.json"
 
@@ -342,7 +342,7 @@ madsonic_task:
   only_if: "changesInclude('madsonic.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "madsonic.json"
 
@@ -360,7 +360,7 @@ monica_task:
   only_if: "changesInclude('monica.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "monica.json"
 
@@ -369,7 +369,7 @@ mosquitto_task:
   only_if: "changesInclude('mosquitto.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "mosquitto.json"
 
@@ -387,7 +387,7 @@ netdata_task:
   only_if: "changesInclude('netdata.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "netdata.json"
 
@@ -396,7 +396,7 @@ node-red_task:
   only_if: "changesInclude('node-red.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "node-red.json"
 
@@ -405,7 +405,7 @@ nzbget_task:
   only_if: "changesInclude('nzbget.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "nzbget.json"
 
@@ -414,7 +414,7 @@ openspeedtest-server_task:
   only_if: "changesInclude('openspeedtest-server.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "openspeedtest-server.json"
 
@@ -423,7 +423,7 @@ openvpn_task:
   only_if: "changesInclude('openvpn.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "openvpn.json"
 
@@ -432,7 +432,7 @@ privatebin_task:
   only_if: "changesInclude('privatebin.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "privatebin.json"
 
@@ -441,7 +441,7 @@ qbittorrent_task:
   only_if: "changesInclude('qbittorrent.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "qbittorrent.json"
 
@@ -450,7 +450,7 @@ quasselcore_task:
   only_if: "changesInclude('quasselcore.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "quasselcore.json"
 
@@ -459,7 +459,7 @@ radarr_task:
   only_if: "changesInclude('radarr.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "radarr.json"
 
@@ -468,7 +468,7 @@ rslsync_task:
   only_if: "changesInclude('rslsync.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "rslsync.json"
 
@@ -477,7 +477,7 @@ rtorrent-flood_task:
   only_if: "changesInclude('rtorrent-flood.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "rtorrent-flood.json"
 
@@ -486,7 +486,7 @@ sabnzbd_task:
   only_if: "changesInclude('sabnzbd.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "sabnzbd.json"
 
@@ -495,7 +495,7 @@ sickchill_task:
   only_if: "changesInclude('sickchill.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "sickchill.json"
 
@@ -504,7 +504,7 @@ sonarr_task:
   only_if: "changesInclude('sonarr.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "sonarr.json"
 
@@ -513,7 +513,7 @@ tasmoadmin_task:
   only_if: "changesInclude('tasmoadmin.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "tasmoadmin.json"
 
@@ -522,7 +522,7 @@ tautulli_task:
   only_if: "changesInclude('tautulli.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "tautulli.json"
 
@@ -531,7 +531,7 @@ transmission_task:
   only_if: "changesInclude('transmission.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "transmission.json"
 
@@ -540,7 +540,7 @@ unificontroller_task:
   only_if: "changesInclude('unificontroller.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "unificontroller.json"
 
@@ -549,7 +549,7 @@ unificontroller-lts_task:
   only_if: "changesInclude('unificontroller-lts.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "unificontroller-lts.json"
 
@@ -558,7 +558,7 @@ vault_task:
   only_if: "changesInclude('vault.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "vault.json"
 
@@ -567,7 +567,7 @@ weechat_task:
   only_if: "changesInclude('weechat.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "weechat.json"
 
@@ -576,7 +576,7 @@ xmrig_task:
   only_if: "changesInclude('xmrig.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "xmrig.json"
 
@@ -585,7 +585,7 @@ zoneminder_task:
   only_if: "changesInclude('zoneminder.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "zoneminder.json"
 
@@ -594,7 +594,7 @@ zrepl_task:
   only_if: "changesInclude('zrepl.json')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "zrepl.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,9 @@ freebsd_instance:
   memory: "1"
 
 install_template: &INSTALL_PLUGIN
-  requirements_script: pkg install --yes jq
+  requirements_script: |
+    pkg delete --all --yes
+    pkg install --yes jq
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)
     name=$(jq '.name' $PLUGIN_FILE)
@@ -80,20 +82,12 @@ install_template: &INSTALL_PLUGIN
     git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
 
     # Cleanup before plugin pkg installation
-    if ! echo ${pkgs} | grep -q "git"
-    then
-      pkg remove --yes git-lite git jq
-      pkg autoremove --yes
-    fi
+    pkg remove --yes git-lite git jq ca_root_nss
+    pkg autoremove --yes
 
     echo "Fetching $name pkgs: $pkgs"
     pkg update
     pkg fetch --dependencies --yes $pkgs
-
-    if ! echo ${pkgs} | grep -q "ca_root_nss"
-    then
-      pkg remove --force --yes ca_root_nss
-    fi
 
     echo "Installing $name pkgs: $pkgs"
     pkg install --no-repo-update --yes $pkgs

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,11 @@ freebsd_instance:
   cpu: 1
   memory: "1"
 
+install_backuppc: &INSTALL_PLUGIN
+  requirements_script: pkg install -y jq
+  env:
+    PLUGIN_FILE: "backuppc.json"
+
 install_bazarr: &INSTALL_PLUGIN
   requirements_script: pkg install -y jq
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,12 +82,14 @@ install_template: &INSTALL_PLUGIN
     git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
 
     # Cleanup before plugin pkg installation
-    pkg remove --yes git-lite git jq ca_root_nss
+    pkg remove --yes git-lite git jq
     pkg autoremove --yes
 
     echo "Fetching $name pkgs: $pkgs"
     pkg update
     pkg fetch --dependencies --yes $pkgs
+
+    pkg remove --yes ca_root_nss
 
     echo "Installing $name pkgs: $pkgs"
     pkg install --no-repo-update --yes $pkgs

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,19 +3,8 @@ freebsd_instance:
   cpu: 1
   memory: "1"
 
-install_backuppc: &INSTALL_PLUGIN
+task: &INSTALL_PLUGIN:
   requirements_script: pkg install -y jq
-  env:
-    PLUGIN_FILE: "backuppc.json"
-
-install_bazarr: &INSTALL_PLUGIN
-  requirements_script: pkg install -y jq
-  env:
-    PLUGIN_FILE: "bazarr.json"
-
-
-task:
-  <<: *INSTALL_PLUGIN
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)
     name=$(jq '.name' $PLUGIN_FILE)
@@ -96,3 +85,13 @@ task:
     then
       ./plugin/post_update.sh
     fi
+
+install_backuppc:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "backuppc.json"
+
+install_bazarr:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "bazarr.json"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,13 +63,13 @@ install_template: &INSTALL_PLUGIN
 
     pkg install -y git-lite
     git clone ${plugin_repo} ./plugin
-    if [ -d "./plugin/overlay" ];
+    if [ -d "./plugin/overlay" ]
     then
-      echo "Found overlay folder";
+      echo "Found overlay folder"
       cp -r ./plugin/overlay/ /
     fi
 
-    if ! echo ${pkgs} | grep -q git-lite
+    if ! echo ${pkgs} | grep -q "git"
     then
       pkg remove -y git-lite
     fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
   memory: "1"
 
 install_template: &INSTALL_PLUGIN
-  requirements_script: pkg install -y jq ca_root_nss
+  requirements_script: pkg install --yes jq
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)
     name=$(jq '.name' $PLUGIN_FILE)
@@ -12,6 +12,11 @@ install_template: &INSTALL_PLUGIN
     plugin_repo=$(jq -r '.artifact' $PLUGIN_FILE)
     pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
     kmods=$(jq -r '.kmods' $PLUGIN_FILE)
+
+    if echo ${packagesite} | grep -q "https"
+    then
+      pkg install -y ca_root_nss
+    fi
 
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"
@@ -77,13 +82,21 @@ install_template: &INSTALL_PLUGIN
     # Cleanup before plugin pkg installation
     if ! echo ${pkgs} | grep -q "git"
     then
-      pkg remove -y git-lite git jq ca_root_nss
-      pkg autoremove -y
+      pkg remove --yes git-lite git jq
+      pkg autoremove --yes
     fi
 
-    echo "Test install plugin pkgs for plugin: $name"
+    echo "Fetching $name pkgs: $pkgs"
+    pkg update
+    pkg fetch --dependencies --yes $pkgs
+
+    if ! echo ${pkgs} | grep -q "ca_root_nss"
+    then
+      pkg remove --force --yes ca_root_nss
+    fi
+
     echo "Installing $name pkgs: $pkgs"
-    pkg install -y $pkgs
+    pkg install --no-repo-update --yes $pkgs
 
     if [ -d "./plugin/overlay" ]
     then

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -245,7 +245,7 @@ gogs_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "gogs.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,6 @@ install_backuppc_task:
     plugin_repo=$(jq '.artifact' $plugin_file)
 
     pkg install -y git-lite
-    mkdir plugin
     git clone ${plugin_repo} plugin
     pkg remove -y git-lite
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,11 @@ install_template: &INSTALL_PLUGIN
       pkg install -y ca_root_nss
     fi
 
+    pkg install -y git-lite || pkg install -y git
+
+    release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
+    git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
+
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"
     fingerprints_dir="${pkg_dir}/fingerprints"
@@ -72,11 +77,6 @@ install_template: &INSTALL_PLUGIN
         kldload -nv ${kmod}
       done
     fi
-
-    pkg install -y git-lite || pkg install -y git
-
-    release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
-    git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
 
     # Cleanup before plugin pkg installation
     pkg delete --yes git-lite git jq

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,6 +89,10 @@ backuppc_task:
         image_family: freebsd-12-2
         cpu: 1
         memory: 1
+    - freebsd_instance:
+        image_family: freebsd-12-1
+        cpu: 1
+        memory: 1
   env:
     PLUGIN_FILE: "backuppc.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,15 +3,20 @@ freebsd_instance:
   cpu: 1
   memory: "1"
 
-install_task:
+install_bazarr: &INSTALL_PLUGIN
   requirements_script: pkg install -y jq
+  env:
+    PLUGIN_FILE: "bazarr.json"
+
+
+task:
+  <<: *INSTALL_PLUGIN
   install_script: |
-    plugin_file=bazarr.json
-    release=$(jq -r '.release' $plugin_file)
-    name=$(jq '.name' $plugin_file)
-    packagesite=$(jq '.packagesite' $plugin_file)
-    fingerprints=$(jq -r '.fingerprints | keys[]' $plugin_file)
-    plugin_repo=$(jq -r '.artifact' $plugin_file)
+    release=$(jq -r '.release' $PLUGIN_FILE)
+    name=$(jq '.name' $PLUGIN_FILE)
+    packagesite=$(jq '.packagesite' $PLUGIN_FILE)
+    fingerprints=$(jq -r '.fingerprints | keys[]' $PLUGIN_FILE)
+    plugin_repo=$(jq -r '.artifact' $PLUGIN_FILE)
 
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"
@@ -28,7 +33,6 @@ install_task:
     echo "fingerprints \"${fingerprints_dir}\"," >> $pkg_conf_path
     echo "enabled: true" >> $pkg_conf_path
     echo } >> $pkg_conf_path
-
     echo "Created test pkg config file:"
     cat $pkg_conf_path
 
@@ -37,7 +41,7 @@ install_task:
 
     for repo_name in $fingerprints
     do
-      repo_fingerprints=$(jq -rc '."fingerprints"."'${repo_name}'"[]' $plugin_file)
+      repo_fingerprints=$(jq -rc '."fingerprints"."'${repo_name}'"[]' $PLUGIN_FILE)
 
       repo_count=1
       echo $repo_fingerprints | while IFS='' read f
@@ -59,7 +63,7 @@ install_task:
     done
 
     echo "Test install plugin pkgs for plugin: $name"
-    pkgs=$(jq -r '.pkgs | join(" ")' $plugin_file)
+    pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
     echo "Installing $name pkgs: $pkgs"
     pkg install -y $pkgs
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,16 +81,16 @@ install_template: &INSTALL_PLUGIN
       cp -r ./plugin/overlay/ /
     fi
 
-    source ./plugin/post_install.sh
+    . ./plugin/post_install.sh
 
     if [ -f ./plugin/pre_update.sh ]
     then
-      source ./plugin/pre_update.sh
+      . ./plugin/pre_update.sh
     fi
 
     if [ -f ./plugin/post_update.sh ]
     then
-      source ./plugin/post_update.sh
+      . ./plugin/post_update.sh
     fi
 
 backuppc_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,7 @@ install_template: &INSTALL_PLUGIN
     pkg update
     pkg fetch --dependencies --yes $pkgs
 
-    pkg remove --yes ca_root_nss
+    pkg remove --yes ca_root_nss || true
 
     echo "Installing $name pkgs: $pkgs"
     pkg install --no-repo-update --yes $pkgs

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,14 +14,14 @@ install_backuppc_task:
     plugin_repo=$(jq -r '.artifact' $plugin_file)
 
     pkg install -y git-lite
-    git clone ${plugin_repo} plugin
-    if [ -d "/plugin/overlay" ];
+    git clone ${plugin_repo} ./plugin
+    if [ -d "./plugin/overlay" ];
     then
       echo "Found overlay folder";
-      cp -r plugin/overlay /
+      cp -r ./plugin/overlay /
     fi
 
-    ls -l cat usr/local/etc/apache24/httpd.conf
+    cat /usr/local/etc/apache24/httpd.conf
     pkg remove -y git-lite
 
     pkg_dir=/usr/local/test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,6 @@ freebsd_instance:
 
 install_template: &INSTALL_PLUGIN
   requirements_script: |
-    pkg delete --all --yes
     pkg install --yes jq
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)
@@ -15,15 +14,9 @@ install_template: &INSTALL_PLUGIN
     pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
     kmods=$(jq -r '.kmods' $PLUGIN_FILE)
 
+    # Clone plugins artifacts
     plugin_dir="./plugin"
-
-    if echo ${packagesite} | grep -q "https"
-    then
-      pkg install -y ca_root_nss
-    fi
-
-    pkg install -y git-lite || pkg install -y git
-
+    pkg install --yes git-lite || pkg install --yes git
     release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
     git clone -b ${release_branch} ${plugin_repo} ${plugin_dir} || git clone -b master ${plugin_repo} ${plugin_dir}
 
@@ -33,7 +26,6 @@ install_template: &INSTALL_PLUGIN
 
     echo "Creating main repos dir: ${repos_dir}"
     mkdir -p $repos_dir
-    export REPOS_DIR=$repos_dir
 
     pkg_conf_path="${repos_dir}/test.conf"
     echo "iocage-plugins: {" > $pkg_conf_path
@@ -80,13 +72,20 @@ install_template: &INSTALL_PLUGIN
       done
     fi
 
-    # Cleanup before plugin pkg installation
-    pkg delete --yes git-lite git jq
+    # Clean up all packages
+    pkg delete --all --yes
     pkg autoremove --yes
     pkg clean --yes
 
+    if echo ${packagesite} | grep -q "https"
+    then
+      pkg install --yes ca_root_nss
+    fi
+
+    # Start using plugin repos
+    export REPOS_DIR=$repos_dir
+
     echo "Fetching $name pkgs: $pkgs"
-    pkg update
     pkg fetch --dependencies --yes $pkgs
 
     pkg delete --yes ca_root_nss || true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,7 +118,7 @@ backuppc_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "backuppc.json"
 
@@ -142,7 +142,7 @@ calibre-web_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "calibre-web.json"
 
@@ -166,7 +166,7 @@ deluge-pip_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "deluge-pip.json"
 
@@ -214,7 +214,7 @@ esphome_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-11-3
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "esphome.json"
 
@@ -358,7 +358,7 @@ monica_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "monica.json"
 
@@ -390,7 +390,7 @@ node-red_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "node-red.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,16 +81,16 @@ install_template: &INSTALL_PLUGIN
       cp -r ./plugin/overlay/ /
     fi
 
-    . ./plugin/post_install.sh
+    ./plugin/post_install.sh
 
     if [ -f ./plugin/pre_update.sh ]
     then
-      . ./plugin/pre_update.sh
+      ./plugin/pre_update.sh
     fi
 
     if [ -f ./plugin/post_update.sh ]
     then
-      . ./plugin/post_update.sh
+      ./plugin/post_update.sh
     fi
 
 backuppc_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,233 +88,291 @@ install_template: &INSTALL_PLUGIN
 
 install_backuppc_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('backuppc.json')"
   env:
     PLUGIN_FILE: "backuppc.json"
 install_bazarr_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('bazarr.json')"
   env:
     PLUGIN_FILE: "bazarr.json"
 install_bind_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('bind.json')"
   env:
     PLUGIN_FILE: "bind.json"
 install_calibre-web_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('calibre-web.json')"
   env:
     PLUGIN_FILE: "calibre-web.json"
 install_channels-dvr_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('channels-dvr.json')"
   env:
     PLUGIN_FILE: "channels-dvr.json"
 install_clamav_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('clamav.json')"
   env:
     PLUGIN_FILE: "clamav.json"
 install_deluge-pip_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('deluge-pip.json')"
   env:
     PLUGIN_FILE: "deluge-pip.json"
 install_dnsmasq_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('dnsmasq.json')"
   env:
     PLUGIN_FILE: "dnsmasq.json"
 install_drupal8_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('drupal8.json')"
   env:
     PLUGIN_FILE: "drupal8.json"
 install_duplicati_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('duplicati.json')"
   env:
     PLUGIN_FILE: "duplicati.json"
 install_emby_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('emby.json')"
   env:
     PLUGIN_FILE: "emby.json"
 install_emby-server-stable_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('emby-server-stable.json')"
   env:
     PLUGIN_FILE: "emby-server-stable.json"
 install_esphome_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('esphome.json')"
   env:
     PLUGIN_FILE: "esphome.json"
 install_famp_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('famp.json')"
   env:
     PLUGIN_FILE: "famp.json"
 install_gitea_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('gitea.json')"
   env:
     PLUGIN_FILE: "gitea.json"
 install_gitlab_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('gitlab.json')"
   env:
     PLUGIN_FILE: "gitlab.json"
 install_gogs_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('gogs.json')"
   env:
     PLUGIN_FILE: "gogs.json"
 install_grafana_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('grafana.json')"
   env:
     PLUGIN_FILE: "grafana.json"
 install_heimdall-dashboard_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('heimdall-dashboard.json')"
   env:
     PLUGIN_FILE: "heimdall-dashboard.json"
 install_homeassistant_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('homeassistant.json')"
   env:
     PLUGIN_FILE: "homeassistant.json"
 install_homebridge_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('homebridge.json')"
   env:
     PLUGIN_FILE: "homebridge.json"
 install_hoobs_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('hoobs.json')"
   env:
     PLUGIN_FILE: "hoobs.json"
 install_i2p_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('i2p.json')"
   env:
     PLUGIN_FILE: "i2p.json"
 install_irssi_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('irssi.json')"
   env:
     PLUGIN_FILE: "irssi.json"
 install_jackett_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('jackett.json')"
   env:
     PLUGIN_FILE: "jackett.json"
 install_jenkins_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('jenkins.json')"
   env:
     PLUGIN_FILE: "jenkins.json"
 install_jenkins-lts_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('jenkins-lts.json')"
   env:
     PLUGIN_FILE: "jenkins-lts.json"
 install_lidarr_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('lidarr.json')"
   env:
     PLUGIN_FILE: "lidarr.json"
 install_madsonic_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('madsonic.json')"
   env:
     PLUGIN_FILE: "madsonic.json"
 install_mineos_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('mineos.json')"
   env:
     PLUGIN_FILE: "mineos.json"
 install_monica_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('monica.json')"
   env:
     PLUGIN_FILE: "monica.json"
 install_mosquitto_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('mosquitto.json')"
   env:
     PLUGIN_FILE: "mosquitto.json"
 install_motioneye_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('motioneye.json')"
   env:
     PLUGIN_FILE: "motioneye.json"
 install_netdata_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('netdata.json')"
   env:
     PLUGIN_FILE: "netdata.json"
 install_node-red_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('node-red.json')"
   env:
     PLUGIN_FILE: "node-red.json"
 install_nzbget_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('nzbget.json')"
   env:
     PLUGIN_FILE: "nzbget.json"
 install_openspeedtest-server_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('openspeedtest-server.json')"
   env:
     PLUGIN_FILE: "openspeedtest-server.json"
 install_openvpn_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('openvpn.json')"
   env:
     PLUGIN_FILE: "openvpn.json"
 install_privatebin_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('privatebin.json')"
   env:
     PLUGIN_FILE: "privatebin.json"
 install_qbittorrent_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('qbittorrent.json')"
   env:
     PLUGIN_FILE: "qbittorrent.json"
 install_quasselcore_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('quasselcore.json')"
   env:
     PLUGIN_FILE: "quasselcore.json"
 install_radarr_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('radarr.json')"
   env:
     PLUGIN_FILE: "radarr.json"
 install_rslsync_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('rslsync.json')"
   env:
     PLUGIN_FILE: "rslsync.json"
 install_rtorrent-flood_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('rtorrent-flood.json')"
   env:
     PLUGIN_FILE: "rtorrent-flood.json"
 install_sabnzbd_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('sabnzbd.json')"
   env:
     PLUGIN_FILE: "sabnzbd.json"
 install_sickchill_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('sickchill.json')"
   env:
     PLUGIN_FILE: "sickchill.json"
 install_sonarr_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('sonarr.json')"
   env:
     PLUGIN_FILE: "sonarr.json"
 install_tasmoadmin_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('tasmoadmin.json')"
   env:
     PLUGIN_FILE: "tasmoadmin.json"
 install_tautulli_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('tautulli.json')"
   env:
     PLUGIN_FILE: "tautulli.json"
 install_transmission_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('transmission.json')"
   env:
     PLUGIN_FILE: "transmission.json"
 install_unificontroller_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('unificontroller.json')"
   env:
     PLUGIN_FILE: "unificontroller.json"
 install_unificontroller-lts_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('unificontroller-lts.json')"
   env:
     PLUGIN_FILE: "unificontroller-lts.json"
 install_vault_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('vault.json')"
   env:
     PLUGIN_FILE: "vault.json"
 install_weechat_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('weechat.json')"
   env:
     PLUGIN_FILE: "weechat.json"
 install_xmrig_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('xmrig.json')"
   env:
     PLUGIN_FILE: "xmrig.json"
 install_zoneminder_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('zoneminder.json')"
   env:
     PLUGIN_FILE: "zoneminder.json"
 install_zrepl_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('zrepl.json')"
   env:
     PLUGIN_FILE: "zrepl.json"
 install_zwavejs2mqtt_task:
   <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('zwavejs2mqtt.json')"
   env:
     PLUGIN_FILE: "zwavejs2mqtt.json"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
   memory: "1"
 
 install_template: &INSTALL_PLUGIN
-  requirements_script: pkg install -y jq
+  requirements_script: pkg install -y jq ca_root_nss
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)
     name=$(jq '.name' $PLUGIN_FILE)
@@ -76,7 +76,7 @@ install_template: &INSTALL_PLUGIN
     # Cleanup before plugin pkg installation
     if ! echo ${pkgs} | grep -q "git"
     then
-      pkg remove -y git-lite git jq
+      pkg remove -y git-lite git jq ca_root_nss
       pkg autoremove -y
     fi
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,7 @@ install_backuppc_task:
       cp -r plugin/overlay /
     fi
 
+    ls -l cat usr/local/etc/apache24/httpd.conf
     pkg remove -y git-lite
 
     pkg_dir=/usr/local/test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,15 +83,15 @@ install_template: &INSTALL_PLUGIN
 
     ./plugin/post_install.sh
 
-    if ! [ -x ./plugin/pre_update.sh ]
+    if [ -f ./plugin/pre_update.sh ] && ! [ -x ./plugin/pre_update.sh ]
     then
-      echo "pre_update.sh script not found or not executable"
+      echo "pre_update.sh script not executable"
       exit 1
     fi
 
-    if ! [ -x ./plugin/post_update.sh ]
+    if [ -f ./plugin/post_update.sh ] && ! [ -x ./plugin/post_update.sh ]
     then
-      echo "post_update.sh script not found or not executable"
+      echo "post_update.sh script not executable"
       exit 1
     fi
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,8 +60,14 @@ install_template: &INSTALL_PLUGIN
     echo "Installing $name pkgs: $pkgs"
     pkg install -y $pkgs
 
-    pkg install -y git-lite
-    git clone ${plugin_repo} ./plugin
+    if [ "$(which git)" = "" ]
+    then
+      pkg install -y git-lite || pkg install -y git
+    fi
+
+    release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
+    git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
+
     if [ -d "./plugin/overlay" ]
     then
       echo "Found overlay folder"
@@ -70,7 +76,8 @@ install_template: &INSTALL_PLUGIN
 
     if ! echo ${pkgs} | grep -q "git"
     then
-      pkg remove -y git-lite
+      pkg remove -y git-lite git
+      pkg autoremove -y
     fi
 
     ./plugin/post_install.sh
@@ -113,7 +120,7 @@ calibre-web_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "calibre-web.json"
 
@@ -137,7 +144,7 @@ deluge-pip_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "deluge-pip.json"
 
@@ -185,7 +192,7 @@ esphome_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-11-3
   env:
     PLUGIN_FILE: "esphome.json"
 
@@ -241,6 +248,10 @@ homeassistant_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
+        image_family: freebsd-11-2
+    - freebsd_instance:
+        image_family: freebsd-11-3
+    - freebsd_instance:
         image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "homeassistant.json"
@@ -256,6 +267,8 @@ homebridge_task:
 hoobs_task:
   <<: *INSTALL_PLUGIN
   matrix:
+    - freebsd_instance:
+        image_family: freebsd-11-3
     - freebsd_instance:
         image_family: freebsd-12-1
   env:
@@ -329,7 +342,7 @@ monica_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-11-3
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "monica.json"
 
@@ -361,7 +374,7 @@ node-red_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "node-red.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -249,10 +249,6 @@ homeassistant_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-11-2
-    - freebsd_instance:
-        image_family: freebsd-11-3
-    - freebsd_instance:
         image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "homeassistant.json"
@@ -268,8 +264,6 @@ homebridge_task:
 hoobs_task:
   <<: *INSTALL_PLUGIN
   matrix:
-    - freebsd_instance:
-        image_family: freebsd-11-3
     - freebsd_instance:
         image_family: freebsd-12-1
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
   cpu: 1
   memory: "1"
 
-install_template: &INSTALL_PLUGIN:
+install_template: &INSTALL_PLUGIN
   requirements_script: pkg install -y jq
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,7 +81,7 @@ install_template: &INSTALL_PLUGIN
       ./plugin/post_update.sh
     fi
 
-install_backuppc_task:
+backuppc_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('backuppc.json')"
   matrix:
@@ -92,7 +92,7 @@ install_backuppc_task:
   env:
     PLUGIN_FILE: "backuppc.json"
 
-install_bazarr_task:
+bazarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('bazarr.json')"
   matrix:
@@ -103,7 +103,7 @@ install_bazarr_task:
   env:
     PLUGIN_FILE: "bazarr.json"
 
-install_bind_task:
+bind_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('bind.json')"
   matrix:
@@ -114,7 +114,7 @@ install_bind_task:
   env:
     PLUGIN_FILE: "bind.json"
 
-install_calibre-web_task:
+calibre-web_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('calibre-web.json')"
   matrix:
@@ -125,7 +125,7 @@ install_calibre-web_task:
   env:
     PLUGIN_FILE: "calibre-web.json"
 
-install_channels-dvr_task:
+channels-dvr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('channels-dvr.json')"
   matrix:
@@ -136,7 +136,7 @@ install_channels-dvr_task:
   env:
     PLUGIN_FILE: "channels-dvr.json"
 
-install_clamav_task:
+clamav_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('clamav.json')"
   matrix:
@@ -147,7 +147,7 @@ install_clamav_task:
   env:
     PLUGIN_FILE: "clamav.json"
 
-install_deluge-pip_task:
+deluge-pip_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('deluge-pip.json')"
   matrix:
@@ -158,7 +158,7 @@ install_deluge-pip_task:
   env:
     PLUGIN_FILE: "deluge-pip.json"
 
-install_dnsmasq_task:
+dnsmasq_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('dnsmasq.json')"
   matrix:
@@ -169,7 +169,7 @@ install_dnsmasq_task:
   env:
     PLUGIN_FILE: "dnsmasq.json"
 
-install_drupal8_task:
+drupal8_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('drupal8.json')"
   matrix:
@@ -180,7 +180,7 @@ install_drupal8_task:
   env:
     PLUGIN_FILE: "drupal8.json"
 
-install_duplicati_task:
+duplicati_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('duplicati.json')"
   matrix:
@@ -191,7 +191,7 @@ install_duplicati_task:
   env:
     PLUGIN_FILE: "duplicati.json"
 
-install_emby_task:
+emby_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('emby.json')"
   matrix:
@@ -202,7 +202,7 @@ install_emby_task:
   env:
     PLUGIN_FILE: "emby.json"
 
-install_emby-server-stable_task:
+emby-server-stable_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('emby-server-stable.json')"
   matrix:
@@ -213,7 +213,7 @@ install_emby-server-stable_task:
   env:
     PLUGIN_FILE: "emby-server-stable.json"
 
-install_esphome_task:
+esphome_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('esphome.json')"
   matrix:
@@ -224,7 +224,7 @@ install_esphome_task:
   env:
     PLUGIN_FILE: "esphome.json"
 
-install_famp_task:
+famp_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('famp.json')"
   matrix:
@@ -235,7 +235,7 @@ install_famp_task:
   env:
     PLUGIN_FILE: "famp.json"
 
-install_gitea_task:
+gitea_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('gitea.json')"
   matrix:
@@ -246,7 +246,7 @@ install_gitea_task:
   env:
     PLUGIN_FILE: "gitea.json"
 
-install_gitlab_task:
+gitlab_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('gitlab.json')"
   matrix:
@@ -257,7 +257,7 @@ install_gitlab_task:
   env:
     PLUGIN_FILE: "gitlab.json"
 
-install_gogs_task:
+gogs_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('gogs.json')"
   matrix:
@@ -268,7 +268,7 @@ install_gogs_task:
   env:
     PLUGIN_FILE: "gogs.json"
 
-install_grafana_task:
+grafana_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('grafana.json')"
   matrix:
@@ -279,7 +279,7 @@ install_grafana_task:
   env:
     PLUGIN_FILE: "grafana.json"
 
-install_heimdall-dashboard_task:
+heimdall-dashboard_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('heimdall-dashboard.json')"
   matrix:
@@ -290,7 +290,7 @@ install_heimdall-dashboard_task:
   env:
     PLUGIN_FILE: "heimdall-dashboard.json"
 
-install_homeassistant_task:
+homeassistant_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('homeassistant.json')"
   matrix:
@@ -301,7 +301,7 @@ install_homeassistant_task:
   env:
     PLUGIN_FILE: "homeassistant.json"
 
-install_homebridge_task:
+homebridge_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('homebridge.json')"
   matrix:
@@ -312,7 +312,7 @@ install_homebridge_task:
   env:
     PLUGIN_FILE: "homebridge.json"
 
-install_hoobs_task:
+hoobs_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('hoobs.json')"
   matrix:
@@ -323,7 +323,7 @@ install_hoobs_task:
   env:
     PLUGIN_FILE: "hoobs.json"
 
-install_i2p_task:
+i2p_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('i2p.json')"
   matrix:
@@ -334,7 +334,7 @@ install_i2p_task:
   env:
     PLUGIN_FILE: "i2p.json"
 
-install_irssi_task:
+irssi_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('irssi.json')"
   matrix:
@@ -345,7 +345,7 @@ install_irssi_task:
   env:
     PLUGIN_FILE: "irssi.json"
 
-install_jackett_task:
+jackett_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('jackett.json')"
   matrix:
@@ -356,7 +356,7 @@ install_jackett_task:
   env:
     PLUGIN_FILE: "jackett.json"
 
-install_jenkins_task:
+jenkins_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('jenkins.json')"
   matrix:
@@ -367,7 +367,7 @@ install_jenkins_task:
   env:
     PLUGIN_FILE: "jenkins.json"
 
-install_jenkins-lts_task:
+jenkins-lts_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('jenkins-lts.json')"
   matrix:
@@ -378,7 +378,7 @@ install_jenkins-lts_task:
   env:
     PLUGIN_FILE: "jenkins-lts.json"
 
-install_lidarr_task:
+lidarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('lidarr.json')"
   matrix:
@@ -389,7 +389,7 @@ install_lidarr_task:
   env:
     PLUGIN_FILE: "lidarr.json"
 
-install_madsonic_task:
+madsonic_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('madsonic.json')"
   matrix:
@@ -400,7 +400,7 @@ install_madsonic_task:
   env:
     PLUGIN_FILE: "madsonic.json"
 
-install_mineos_task:
+mineos_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('mineos.json')"
   matrix:
@@ -411,7 +411,7 @@ install_mineos_task:
   env:
     PLUGIN_FILE: "mineos.json"
 
-install_monica_task:
+monica_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('monica.json')"
   matrix:
@@ -422,7 +422,7 @@ install_monica_task:
   env:
     PLUGIN_FILE: "monica.json"
 
-install_mosquitto_task:
+mosquitto_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('mosquitto.json')"
   matrix:
@@ -433,7 +433,7 @@ install_mosquitto_task:
   env:
     PLUGIN_FILE: "mosquitto.json"
 
-install_motioneye_task:
+motioneye_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('motioneye.json')"
   matrix:
@@ -444,7 +444,7 @@ install_motioneye_task:
   env:
     PLUGIN_FILE: "motioneye.json"
 
-install_netdata_task:
+netdata_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('netdata.json')"
   matrix:
@@ -455,7 +455,7 @@ install_netdata_task:
   env:
     PLUGIN_FILE: "netdata.json"
 
-install_node-red_task:
+node-red_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('node-red.json')"
   matrix:
@@ -466,7 +466,7 @@ install_node-red_task:
   env:
     PLUGIN_FILE: "node-red.json"
 
-install_nzbget_task:
+nzbget_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('nzbget.json')"
   matrix:
@@ -477,7 +477,7 @@ install_nzbget_task:
   env:
     PLUGIN_FILE: "nzbget.json"
 
-install_openspeedtest-server_task:
+openspeedtest-server_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('openspeedtest-server.json')"
   matrix:
@@ -488,7 +488,7 @@ install_openspeedtest-server_task:
   env:
     PLUGIN_FILE: "openspeedtest-server.json"
 
-install_openvpn_task:
+openvpn_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('openvpn.json')"
   matrix:
@@ -499,7 +499,7 @@ install_openvpn_task:
   env:
     PLUGIN_FILE: "openvpn.json"
 
-install_privatebin_task:
+privatebin_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('privatebin.json')"
   matrix:
@@ -510,7 +510,7 @@ install_privatebin_task:
   env:
     PLUGIN_FILE: "privatebin.json"
 
-install_qbittorrent_task:
+qbittorrent_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('qbittorrent.json')"
   matrix:
@@ -521,7 +521,7 @@ install_qbittorrent_task:
   env:
     PLUGIN_FILE: "qbittorrent.json"
 
-install_quasselcore_task:
+quasselcore_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('quasselcore.json')"
   matrix:
@@ -532,7 +532,7 @@ install_quasselcore_task:
   env:
     PLUGIN_FILE: "quasselcore.json"
 
-install_radarr_task:
+radarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('radarr.json')"
   matrix:
@@ -543,7 +543,7 @@ install_radarr_task:
   env:
     PLUGIN_FILE: "radarr.json"
 
-install_rslsync_task:
+rslsync_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('rslsync.json')"
   matrix:
@@ -554,7 +554,7 @@ install_rslsync_task:
   env:
     PLUGIN_FILE: "rslsync.json"
 
-install_rtorrent-flood_task:
+rtorrent-flood_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('rtorrent-flood.json')"
   matrix:
@@ -565,7 +565,7 @@ install_rtorrent-flood_task:
   env:
     PLUGIN_FILE: "rtorrent-flood.json"
 
-install_sabnzbd_task:
+sabnzbd_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('sabnzbd.json')"
   matrix:
@@ -576,7 +576,7 @@ install_sabnzbd_task:
   env:
     PLUGIN_FILE: "sabnzbd.json"
 
-install_sickchill_task:
+sickchill_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('sickchill.json')"
   matrix:
@@ -587,7 +587,7 @@ install_sickchill_task:
   env:
     PLUGIN_FILE: "sickchill.json"
 
-install_sonarr_task:
+sonarr_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('sonarr.json')"
   matrix:
@@ -598,7 +598,7 @@ install_sonarr_task:
   env:
     PLUGIN_FILE: "sonarr.json"
 
-install_tasmoadmin_task:
+tasmoadmin_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('tasmoadmin.json')"
   matrix:
@@ -609,7 +609,7 @@ install_tasmoadmin_task:
   env:
     PLUGIN_FILE: "tasmoadmin.json"
 
-install_tautulli_task:
+tautulli_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('tautulli.json')"
   matrix:
@@ -620,7 +620,7 @@ install_tautulli_task:
   env:
     PLUGIN_FILE: "tautulli.json"
 
-install_transmission_task:
+transmission_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('transmission.json')"
   matrix:
@@ -631,7 +631,7 @@ install_transmission_task:
   env:
     PLUGIN_FILE: "transmission.json"
 
-install_unificontroller_task:
+unificontroller_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('unificontroller.json')"
   matrix:
@@ -642,7 +642,7 @@ install_unificontroller_task:
   env:
     PLUGIN_FILE: "unificontroller.json"
 
-install_unificontroller-lts_task:
+unificontroller-lts_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('unificontroller-lts.json')"
   matrix:
@@ -653,7 +653,7 @@ install_unificontroller-lts_task:
   env:
     PLUGIN_FILE: "unificontroller-lts.json"
 
-install_vault_task:
+vault_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('vault.json')"
   matrix:
@@ -664,7 +664,7 @@ install_vault_task:
   env:
     PLUGIN_FILE: "vault.json"
 
-install_weechat_task:
+weechat_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('weechat.json')"
   matrix:
@@ -675,7 +675,7 @@ install_weechat_task:
   env:
     PLUGIN_FILE: "weechat.json"
 
-install_xmrig_task:
+xmrig_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('xmrig.json')"
   matrix:
@@ -686,7 +686,7 @@ install_xmrig_task:
   env:
     PLUGIN_FILE: "xmrig.json"
 
-install_zoneminder_task:
+zoneminder_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('zoneminder.json')"
   matrix:
@@ -697,7 +697,7 @@ install_zoneminder_task:
   env:
     PLUGIN_FILE: "zoneminder.json"
 
-install_zrepl_task:
+zrepl_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('zrepl.json')"
   matrix:
@@ -708,7 +708,7 @@ install_zrepl_task:
   env:
     PLUGIN_FILE: "zrepl.json"
 
-install_zwavejs2mqtt_task:
+zwavejs2mqtt_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('zwavejs2mqtt.json')"
   matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,11 +13,10 @@ install_backuppc_task:
     fingerprints=$(jq -r '.fingerprints | keys[]' backuppc.json)
     plugin_repo=$(jq '.artifact' $plugin_file)
 
-    pkg install -y ca_root_nss
-    plugin_archive=$(echo $plugin_repo | sed 's/\.git/\/archive\/master.zip/')
-    fetch ${plugin_archive} plugin.zip
+    pkg install -y git-lite
     mkdir plugin
-    unzip -d plugin plugin.zip
+    git clone ${plugin_archive} plugin
+    pkg remove -y git-lite
 
 
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,14 +83,16 @@ install_template: &INSTALL_PLUGIN
 
     ./plugin/post_install.sh
 
-    if [ -f ./plugin/pre_update.sh ]
+    if ! [ -x ./plugin/pre_update.sh ]
     then
-      ./plugin/pre_update.sh
+      echo "pre_update.sh script not found or not executable"
+      exit 1
     fi
 
-    if [ -f ./plugin/post_update.sh ]
+    if ! [ -x ./plugin/post_update.sh ]
     then
-      ./plugin/post_update.sh
+      echo "post_update.sh script not found or not executable"
+      exit 1
     fi
 
 backuppc_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,3 +77,13 @@ install_backuppc_task:
     fi
 
     ./plugin/post_install.sh
+
+    if [ -f ./plugin/pre_update.sh ]
+    then
+      ./plugin/pre_install.sh
+    fi
+
+    if [ -f ./plugin/post_update.sh ]
+    then
+      ./plugin/post_update.sh
+    fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
   cpu: 1
   memory: "1"
 
-task: &INSTALL_PLUGIN:
+install_template: &INSTALL_PLUGIN:
   requirements_script: pkg install -y jq
   install_script: |
     release=$(jq -r '.release' $PLUGIN_FILE)
@@ -86,12 +86,12 @@ task: &INSTALL_PLUGIN:
       ./plugin/post_update.sh
     fi
 
-install_backuppc:
+install_backuppc_task:
   <<: *INSTALL_PLUGIN
   env:
     PLUGIN_FILE: "backuppc.json"
 
-install_bazarr:
+install_bazarr_task:
   <<: *INSTALL_PLUGIN
   env:
     PLUGIN_FILE: "bazarr.json"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,14 +79,14 @@ install_template: &INSTALL_PLUGIN
     git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
 
     # Cleanup before plugin pkg installation
-    pkg remove --yes git-lite git jq
+    pkg delete --yes git-lite git jq
     pkg autoremove --yes
 
     echo "Fetching $name pkgs: $pkgs"
     pkg update
     pkg fetch --dependencies --yes $pkgs
 
-    pkg remove --yes ca_root_nss || true
+    pkg delete --yes ca_root_nss || true
 
     echo "Installing $name pkgs: $pkgs"
     pkg install --no-repo-update --yes $pkgs

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -269,7 +269,7 @@ homeassistant_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "homeassistant.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,8 +90,231 @@ install_backuppc_task:
   <<: *INSTALL_PLUGIN
   env:
     PLUGIN_FILE: "backuppc.json"
-
 install_bazarr_task:
   <<: *INSTALL_PLUGIN
   env:
     PLUGIN_FILE: "bazarr.json"
+install_bind_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "bind.json"
+install_calibre-web_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "calibre-web.json"
+install_channels-dvr_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "channels-dvr.json"
+install_clamav_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "clamav.json"
+install_deluge-pip_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "deluge-pip.json"
+install_dnsmasq_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "dnsmasq.json"
+install_drupal8_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "drupal8.json"
+install_duplicati_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "duplicati.json"
+install_emby_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "emby.json"
+install_emby-server-stable_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "emby-server-stable.json"
+install_esphome_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "esphome.json"
+install_famp_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "famp.json"
+install_gitea_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "gitea.json"
+install_gitlab_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "gitlab.json"
+install_gogs_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "gogs.json"
+install_grafana_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "grafana.json"
+install_heimdall-dashboard_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "heimdall-dashboard.json"
+install_homeassistant_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "homeassistant.json"
+install_homebridge_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "homebridge.json"
+install_hoobs_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "hoobs.json"
+install_i2p_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "i2p.json"
+install_irssi_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "irssi.json"
+install_jackett_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "jackett.json"
+install_jenkins_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "jenkins.json"
+install_jenkins-lts_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "jenkins-lts.json"
+install_lidarr_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "lidarr.json"
+install_madsonic_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "madsonic.json"
+install_mineos_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "mineos.json"
+install_monica_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "monica.json"
+install_mosquitto_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "mosquitto.json"
+install_motioneye_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "motioneye.json"
+install_netdata_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "netdata.json"
+install_node-red_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "node-red.json"
+install_nzbget_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "nzbget.json"
+install_openspeedtest-server_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "openspeedtest-server.json"
+install_openvpn_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "openvpn.json"
+install_privatebin_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "privatebin.json"
+install_qbittorrent_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "qbittorrent.json"
+install_quasselcore_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "quasselcore.json"
+install_radarr_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "radarr.json"
+install_rslsync_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "rslsync.json"
+install_rtorrent-flood_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "rtorrent-flood.json"
+install_sabnzbd_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "sabnzbd.json"
+install_sickchill_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "sickchill.json"
+install_sonarr_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "sonarr.json"
+install_tasmoadmin_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "tasmoadmin.json"
+install_tautulli_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "tautulli.json"
+install_transmission_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "transmission.json"
+install_unificontroller_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "unificontroller.json"
+install_unificontroller-lts_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "unificontroller-lts.json"
+install_vault_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "vault.json"
+install_weechat_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "weechat.json"
+install_xmrig_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "xmrig.json"
+install_zoneminder_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "zoneminder.json"
+install_zrepl_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "zrepl.json"
+install_zwavejs2mqtt_task:
+  <<: *INSTALL_PLUGIN
+  env:
+    PLUGIN_FILE: "zwavejs2mqtt.json"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,57 +13,57 @@ install_backuppc_task:
     fingerprints=$(jq -r '.fingerprints | keys[]' backuppc.json)
     plugin_repo=$(jq '.artifact' $plugin_file)
 
-    pkg_dir=/usr/local/test
-    repos_dir="${pkg_dir}/repos"
-    fingerprints_dir="${pkg_dir}/fingerprints"
+#    pkg_dir=/usr/local/test
+#    repos_dir="${pkg_dir}/repos"
+#    fingerprints_dir="${pkg_dir}/fingerprints"
+#
+#    echo "Creating main repos dir: ${repos_dir}"
+#    mkdir -p $repos_dir
+#    export REPOS_DIR=$repos_dir
+#
+#    pkg_conf_path="${repos_dir}/test.conf"
+#    echo "iocage-plugins: {" > $pkg_conf_path
+#    echo "url: $packagesite," >> $pkg_conf_path
+#    echo "signature_type: \"fingerprints\"," >> $pkg_conf_path
+#    echo "fingerprints \"${fingerprints_dir}\"," >> $pkg_conf_path
+#    echo "enabled: true" >> $pkg_conf_path
+#    echo } >> $pkg_conf_path
+#
+#    echo "Created test pkg config file:"
+#    cat $pkg_conf_path
+#
+#    trusted_fingerprints="$fingerprints_dir/trusted"
+#    mkdir -p "${trusted_fingerprints}"
+#
+#    for repo_name in $fingerprints
+#    do
+#      repo_fingerprints=$(jq -rc '."fingerprints"."'${repo_name}'"[]' $plugin_file)
+#
+#      repo_count=1
+#      echo $repo_fingerprints | while IFS='' read f
+#      do
+#        echo "Creating fingerprint file for repo:"
+#        echo $f
+#
+#        function=$(echo $f | jq -r '.function')
+#        fingerprint=$(echo $f | jq -r '.fingerprint')
+#        file_path=${trusted_fingerprints}/${repo_name}_${repo_count}
+#
+#        echo "Creating new fingerprint file: ${file_path}"
+#
+#        echo "function: $function" > ${file_path}
+#        echo "fingerprint: $fingerprint" >> ${file_path}
+#
+#        repo_count=$(expr $repo_count + 1)
+#      done
+#    done
+#
+#    echo "Test install plugin pkgs for plugin: $name"
+#    pkgs=$(jq -r '.pkgs | join(" ")' $plugin_file)
+#    echo "Installing $name pkgs: $pkgs"
+#    pkg install -y $pkgs
 
-    echo "Creating main repos dir: ${repos_dir}"
-    mkdir -p $repos_dir
-    export REPOS_DIR=$repos_dir
-
-    pkg_conf_path="${repos_dir}/test.conf"
-    echo "iocage-plugins: {" > $pkg_conf_path
-    echo "url: $packagesite," >> $pkg_conf_path
-    echo "signature_type: \"fingerprints\"," >> $pkg_conf_path
-    echo "fingerprints \"${fingerprints_dir}\"," >> $pkg_conf_path
-    echo "enabled: true" >> $pkg_conf_path
-    echo } >> $pkg_conf_path
-
-    echo "Created test pkg config file:"
-    cat $pkg_conf_path
-
-    trusted_fingerprints="$fingerprints_dir/trusted"
-    mkdir -p "${trusted_fingerprints}"
-
-    for repo_name in $fingerprints
-    do
-      repo_fingerprints=$(jq -rc '."fingerprints"."'${repo_name}'"[]' $plugin_file)
-
-      repo_count=1
-      echo $repo_fingerprints | while IFS='' read f
-      do
-        echo "Creating fingerprint file for repo:"
-        echo $f
-
-        function=$(echo $f | jq -r '.function')
-        fingerprint=$(echo $f | jq -r '.fingerprint')
-        file_path=${trusted_fingerprints}/${repo_name}_${repo_count}
-
-        echo "Creating new fingerprint file: ${file_path}"
-
-        echo "function: $function" > ${file_path}
-        echo "fingerprint: $fingerprint" >> ${file_path}
-
-        repo_count=$(expr $repo_count + 1)
-      done
-    done
-
-    echo "Test install plugin pkgs for plugin: $name"
-    pkgs=$(jq -r '.pkgs | join(" ")' $plugin_file)
-    echo "Installing $name pkgs: $pkgs"
-    pkg install -y $pkgs
-
-    pkg install ca_root_nss
+    pkg install -y ca_root_nss
     plugin_archive=$(echo $plugin_repo | sed 's/\.git/\/archive\/master.zip/')
     fetch ${plugin_archive} plugin.zip
     mkdir plugin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -493,7 +493,7 @@ tasmoadmin_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "tasmoadmin.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ install_backuppc_task:
     if [ -d "./plugin/overlay" ];
     then
       echo "Found overlay folder";
-      cp -r ./plugin/overlay /
+      cp -r ./plugin/overlay/ /
     fi
 
     cat /usr/local/etc/apache24/httpd.conf

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,7 @@ install_template: &INSTALL_PLUGIN
     packagesite=$(jq '.packagesite' $PLUGIN_FILE)
     fingerprints=$(jq -r '.fingerprints | keys[]' $PLUGIN_FILE)
     plugin_repo=$(jq -r '.artifact' $PLUGIN_FILE)
+    pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
 
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"
@@ -71,7 +72,6 @@ install_template: &INSTALL_PLUGIN
     fi
 
     echo "Test install plugin pkgs for plugin: $name"
-    pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
     echo "Installing $name pkgs: $pkgs"
     pkg install -y $pkgs
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,8 +91,6 @@ backuppc_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-    - freebsd_instance:
-        image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "backuppc.json"
 
@@ -102,8 +100,6 @@ bazarr_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "bazarr.json"
 
@@ -113,8 +109,6 @@ bind_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "bind.json"
 
@@ -124,8 +118,6 @@ calibre-web_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "calibre-web.json"
 
@@ -135,8 +127,6 @@ channels-dvr_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "channels-dvr.json"
 
@@ -146,8 +136,6 @@ clamav_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "clamav.json"
 
@@ -157,8 +145,6 @@ deluge-pip_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "deluge-pip.json"
 
@@ -168,8 +154,6 @@ dnsmasq_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "dnsmasq.json"
 
@@ -179,8 +163,6 @@ drupal8_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "drupal8.json"
 
@@ -190,8 +172,6 @@ duplicati_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "duplicati.json"
 
@@ -201,8 +181,6 @@ emby_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "emby.json"
 
@@ -212,8 +190,6 @@ emby-server-stable_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "emby-server-stable.json"
 
@@ -223,8 +199,6 @@ esphome_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "esphome.json"
 
@@ -234,8 +208,6 @@ famp_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "famp.json"
 
@@ -245,8 +217,6 @@ gitea_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "gitea.json"
 
@@ -256,8 +226,6 @@ gitlab_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "gitlab.json"
 
@@ -267,8 +235,6 @@ gogs_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "gogs.json"
 
@@ -278,8 +244,6 @@ grafana_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "grafana.json"
 
@@ -289,8 +253,6 @@ heimdall-dashboard_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "heimdall-dashboard.json"
 
@@ -300,8 +262,6 @@ homeassistant_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "homeassistant.json"
 
@@ -311,8 +271,6 @@ homebridge_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "homebridge.json"
 
@@ -322,8 +280,6 @@ hoobs_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "hoobs.json"
 
@@ -333,8 +289,6 @@ i2p_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "i2p.json"
 
@@ -344,8 +298,6 @@ irssi_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "irssi.json"
 
@@ -355,8 +307,6 @@ jackett_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "jackett.json"
 
@@ -366,8 +316,6 @@ jenkins_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "jenkins.json"
 
@@ -377,8 +325,6 @@ jenkins-lts_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "jenkins-lts.json"
 
@@ -388,8 +334,6 @@ lidarr_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "lidarr.json"
 
@@ -399,8 +343,6 @@ madsonic_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "madsonic.json"
 
@@ -410,8 +352,6 @@ mineos_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "mineos.json"
 
@@ -421,8 +361,6 @@ monica_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "monica.json"
 
@@ -432,8 +370,6 @@ mosquitto_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "mosquitto.json"
 
@@ -443,8 +379,6 @@ motioneye_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "motioneye.json"
 
@@ -454,8 +388,6 @@ netdata_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "netdata.json"
 
@@ -465,8 +397,6 @@ node-red_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "node-red.json"
 
@@ -476,8 +406,6 @@ nzbget_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "nzbget.json"
 
@@ -487,8 +415,6 @@ openspeedtest-server_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "openspeedtest-server.json"
 
@@ -498,8 +424,6 @@ openvpn_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "openvpn.json"
 
@@ -509,8 +433,6 @@ privatebin_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "privatebin.json"
 
@@ -520,8 +442,6 @@ qbittorrent_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "qbittorrent.json"
 
@@ -531,8 +451,6 @@ quasselcore_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "quasselcore.json"
 
@@ -542,8 +460,6 @@ radarr_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "radarr.json"
 
@@ -553,8 +469,6 @@ rslsync_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "rslsync.json"
 
@@ -564,8 +478,6 @@ rtorrent-flood_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "rtorrent-flood.json"
 
@@ -575,8 +487,6 @@ sabnzbd_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "sabnzbd.json"
 
@@ -586,8 +496,6 @@ sickchill_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "sickchill.json"
 
@@ -597,8 +505,6 @@ sonarr_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "sonarr.json"
 
@@ -608,8 +514,6 @@ tasmoadmin_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "tasmoadmin.json"
 
@@ -619,8 +523,6 @@ tautulli_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "tautulli.json"
 
@@ -630,8 +532,6 @@ transmission_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "transmission.json"
 
@@ -641,8 +541,6 @@ unificontroller_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "unificontroller.json"
 
@@ -652,8 +550,6 @@ unificontroller-lts_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "unificontroller-lts.json"
 
@@ -663,8 +559,6 @@ vault_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "vault.json"
 
@@ -674,8 +568,6 @@ weechat_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "weechat.json"
 
@@ -685,8 +577,6 @@ xmrig_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "xmrig.json"
 
@@ -696,8 +586,6 @@ zoneminder_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "zoneminder.json"
 
@@ -707,8 +595,6 @@ zrepl_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "zrepl.json"
 
@@ -718,8 +604,6 @@ zwavejs2mqtt_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "zwavejs2mqtt.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,7 @@ install_template: &INSTALL_PLUGIN
     fingerprints=$(jq -r '.fingerprints | keys[]' $PLUGIN_FILE)
     plugin_repo=$(jq -r '.artifact' $PLUGIN_FILE)
     pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
+    kmods=$(jq -r '.kmods' $PLUGIN_FILE)
 
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,11 +55,6 @@ install_template: &INSTALL_PLUGIN
       done
     done
 
-    echo "Test install plugin pkgs for plugin: $name"
-    pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
-    echo "Installing $name pkgs: $pkgs"
-    pkg install -y $pkgs
-
     if [ "$(which git)" = "" ]
     then
       pkg install -y git-lite || pkg install -y git
@@ -68,16 +63,22 @@ install_template: &INSTALL_PLUGIN
     release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
     git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
 
+    # Cleanup before plugin pkg installation
+    if ! echo ${pkgs} | grep -q "git"
+    then
+      pkg remove -y git-lite git jq
+      pkg autoremove -y
+    fi
+
+    echo "Test install plugin pkgs for plugin: $name"
+    pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
+    echo "Installing $name pkgs: $pkgs"
+    pkg install -y $pkgs
+
     if [ -d "./plugin/overlay" ]
     then
       echo "Found overlay folder"
       cp -r ./plugin/overlay/ /
-    fi
-
-    if ! echo ${pkgs} | grep -q "git"
-    then
-      pkg remove -y git-lite git
-      pkg autoremove -y
     fi
 
     ./plugin/post_install.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,7 +78,7 @@ install_template: &INSTALL_PLUGIN
 
     if [ -f ./plugin/pre_update.sh ]
     then
-      ./plugin/pre_install.sh
+      ./plugin/pre_update.sh
     fi
 
     if [ -f ./plugin/post_update.sh ]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,8 @@ install_template: &INSTALL_PLUGIN
     pkgs=$(jq -r '.pkgs | join(" ")' $PLUGIN_FILE)
     kmods=$(jq -r '.kmods' $PLUGIN_FILE)
 
+    plugin_dir="./plugin"
+
     if echo ${packagesite} | grep -q "https"
     then
       pkg install -y ca_root_nss
@@ -23,7 +25,7 @@ install_template: &INSTALL_PLUGIN
     pkg install -y git-lite || pkg install -y git
 
     release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
-    git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin
+    git clone -b ${release_branch} ${plugin_repo} ${plugin_dir} || git clone -b master ${plugin_repo} ${plugin_dir}
 
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"
@@ -91,21 +93,21 @@ install_template: &INSTALL_PLUGIN
     echo "Installing $name pkgs: $pkgs"
     pkg install --no-repo-update --yes $pkgs
 
-    if [ -d "./plugin/overlay" ]
+    if [ -d "${plugin_dir}/overlay" ]
     then
       echo "Found overlay folder"
-      cp -r ./plugin/overlay/ /
+      cp -r ${plugin_dir}/overlay/ /
     fi
 
-    ./plugin/post_install.sh
+    ${plugin_dir}/post_install.sh
 
-    if [ -f ./plugin/pre_update.sh ] && ! [ -x ./plugin/pre_update.sh ]
+    if [ -f ${plugin_dir}/pre_update.sh ] && ! [ -x ${plugin_dir}/pre_update.sh ]
     then
       echo "pre_update.sh script not executable"
       exit 1
     fi
 
-    if [ -f ./plugin/post_update.sh ] && ! [ -x ./plugin/post_update.sh ]
+    if [ -f ${plugin_dir}/post_update.sh ] && ! [ -x ${plugin_dir}/post_update.sh ]
     then
       echo "post_update.sh script not executable"
       exit 1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,10 +15,8 @@ install_backuppc_task:
 
     pkg install -y git-lite
     mkdir plugin
-    git clone ${plugin_archive} plugin
+    git clone ${plugin_repo} plugin
     pkg remove -y git-lite
-
-
 
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,14 +3,14 @@ freebsd_instance:
   cpu: 1
   memory: "1"
 
-install_backuppc_task:
+install_task:
   requirements_script: pkg install -y jq
   install_script: |
-    plugin_file=backuppc.json
+    plugin_file=bazarr.json
     release=$(jq -r '.release' $plugin_file)
     name=$(jq '.name' $plugin_file)
     packagesite=$(jq '.packagesite' $plugin_file)
-    fingerprints=$(jq -r '.fingerprints | keys[]' backuppc.json)
+    fingerprints=$(jq -r '.fingerprints | keys[]' $plugin_file)
     plugin_repo=$(jq -r '.artifact' $plugin_file)
 
     pkg_dir=/usr/local/test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,12 @@ install_backuppc_task:
 
     pkg install -y git-lite
     git clone ${plugin_repo} plugin
+    if [ -d "/plugin/overlay" ];
+    then
+      echo "Found overlay folder";
+      cp -r plugin/overlay /
+    fi
+
     pkg remove -y git-lite
 
     pkg_dir=/usr/local/test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,10 +73,7 @@ install_template: &INSTALL_PLUGIN
       done
     fi
 
-    if [ "$(which git)" = "" ]
-    then
-      pkg install -y git-lite || pkg install -y git
-    fi
+    pkg install -y git-lite || pkg install -y git
 
     release_branch="$(freebsd-version | cut -d '-' -f1)-RELEASE"
     git clone -b ${release_branch} ${plugin_repo} ./plugin || git clone -b master ${plugin_repo} ./plugin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,17 +13,6 @@ install_backuppc_task:
     fingerprints=$(jq -r '.fingerprints | keys[]' backuppc.json)
     plugin_repo=$(jq -r '.artifact' $plugin_file)
 
-    pkg install -y git-lite
-    git clone ${plugin_repo} ./plugin
-    if [ -d "./plugin/overlay" ];
-    then
-      echo "Found overlay folder";
-      cp -r ./plugin/overlay/ /
-    fi
-
-    cat /usr/local/etc/apache24/httpd.conf
-    pkg remove -y git-lite
-
     pkg_dir=/usr/local/test
     repos_dir="${pkg_dir}/repos"
     fingerprints_dir="${pkg_dir}/fingerprints"
@@ -73,3 +62,18 @@ install_backuppc_task:
     pkgs=$(jq -r '.pkgs | join(" ")' $plugin_file)
     echo "Installing $name pkgs: $pkgs"
     pkg install -y $pkgs
+
+    pkg install -y git-lite
+    git clone ${plugin_repo} ./plugin
+    if [ -d "./plugin/overlay" ];
+    then
+      echo "Found overlay folder";
+      cp -r ./plugin/overlay/ /
+    fi
+
+    if ! echo ${pkgs} | grep -q git-lite
+    then
+      pkg remove -y git-lite
+    fi
+
+    ./plugin/post_install.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,7 @@
+freebsd_instance:
+  cpu: 1
+  memory: "1"
+
 install_template: &INSTALL_PLUGIN
   requirements_script: pkg install -y jq
   install_script: |
@@ -87,12 +91,8 @@ backuppc_task:
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
-        cpu: 1
-        memory: 1
     - freebsd_instance:
         image_family: freebsd-12-1
-        cpu: 1
-        memory: 1
   env:
     PLUGIN_FILE: "backuppc.json"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -213,7 +213,7 @@ esphome_task:
   <<: *INSTALL_PLUGIN
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "esphome.json"
 
@@ -576,4 +576,3 @@ zwavejs2mqtt_task:
         image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "zwavejs2mqtt.json"
-

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,7 +87,6 @@ install_template: &INSTALL_PLUGIN
 
 backuppc_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('backuppc.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
@@ -96,7 +95,6 @@ backuppc_task:
 
 bazarr_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('bazarr.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -105,7 +103,6 @@ bazarr_task:
 
 bind_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('bind.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -114,7 +111,6 @@ bind_task:
 
 calibre-web_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('calibre-web.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -123,7 +119,6 @@ calibre-web_task:
 
 channels-dvr_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('channels-dvr.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -132,7 +127,6 @@ channels-dvr_task:
 
 clamav_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('clamav.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -141,7 +135,6 @@ clamav_task:
 
 deluge-pip_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('deluge-pip.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -150,7 +143,6 @@ deluge-pip_task:
 
 dnsmasq_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('dnsmasq.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -159,7 +151,6 @@ dnsmasq_task:
 
 drupal8_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('drupal8.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -168,7 +159,6 @@ drupal8_task:
 
 duplicati_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('duplicati.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -177,7 +167,6 @@ duplicati_task:
 
 emby_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('emby.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -186,7 +175,6 @@ emby_task:
 
 emby-server-stable_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('emby-server-stable.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
@@ -195,7 +183,6 @@ emby-server-stable_task:
 
 esphome_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('esphome.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -204,7 +191,6 @@ esphome_task:
 
 famp_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('famp.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -213,7 +199,6 @@ famp_task:
 
 gitea_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('gitea.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -222,7 +207,6 @@ gitea_task:
 
 gitlab_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('gitlab.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -231,7 +215,6 @@ gitlab_task:
 
 gogs_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('gogs.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -240,7 +223,6 @@ gogs_task:
 
 grafana_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('grafana.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -249,7 +231,6 @@ grafana_task:
 
 heimdall-dashboard_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('heimdall-dashboard.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -258,7 +239,6 @@ heimdall-dashboard_task:
 
 homeassistant_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('homeassistant.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -267,7 +247,6 @@ homeassistant_task:
 
 homebridge_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('homebridge.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -276,7 +255,6 @@ homebridge_task:
 
 hoobs_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('hoobs.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -285,7 +263,6 @@ hoobs_task:
 
 i2p_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('i2p.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -294,7 +271,6 @@ i2p_task:
 
 irssi_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('irssi.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -303,7 +279,6 @@ irssi_task:
 
 jackett_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('jackett.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -312,7 +287,6 @@ jackett_task:
 
 jenkins_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('jenkins.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -321,7 +295,6 @@ jenkins_task:
 
 jenkins-lts_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('jenkins-lts.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -330,7 +303,6 @@ jenkins-lts_task:
 
 lidarr_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('lidarr.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -339,7 +311,6 @@ lidarr_task:
 
 madsonic_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('madsonic.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -348,7 +319,6 @@ madsonic_task:
 
 mineos_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('mineos.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
@@ -357,7 +327,6 @@ mineos_task:
 
 monica_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('monica.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -366,7 +335,6 @@ monica_task:
 
 mosquitto_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('mosquitto.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -375,7 +343,6 @@ mosquitto_task:
 
 motioneye_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('motioneye.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2
@@ -384,7 +351,6 @@ motioneye_task:
 
 netdata_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('netdata.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -393,7 +359,6 @@ netdata_task:
 
 node-red_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('node-red.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -402,7 +367,6 @@ node-red_task:
 
 nzbget_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('nzbget.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -411,7 +375,6 @@ nzbget_task:
 
 openspeedtest-server_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('openspeedtest-server.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -420,7 +383,6 @@ openspeedtest-server_task:
 
 openvpn_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('openvpn.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -429,7 +391,6 @@ openvpn_task:
 
 privatebin_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('privatebin.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -438,7 +399,6 @@ privatebin_task:
 
 qbittorrent_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('qbittorrent.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -447,7 +407,6 @@ qbittorrent_task:
 
 quasselcore_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('quasselcore.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -456,7 +415,6 @@ quasselcore_task:
 
 radarr_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('radarr.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -465,7 +423,6 @@ radarr_task:
 
 rslsync_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('rslsync.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -474,7 +431,6 @@ rslsync_task:
 
 rtorrent-flood_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('rtorrent-flood.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -483,7 +439,6 @@ rtorrent-flood_task:
 
 sabnzbd_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('sabnzbd.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -492,7 +447,6 @@ sabnzbd_task:
 
 sickchill_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('sickchill.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -501,7 +455,6 @@ sickchill_task:
 
 sonarr_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('sonarr.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -510,7 +463,6 @@ sonarr_task:
 
 tasmoadmin_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('tasmoadmin.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -519,7 +471,6 @@ tasmoadmin_task:
 
 tautulli_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('tautulli.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -528,7 +479,6 @@ tautulli_task:
 
 transmission_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('transmission.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -537,7 +487,6 @@ transmission_task:
 
 unificontroller_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('unificontroller.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -546,7 +495,6 @@ unificontroller_task:
 
 unificontroller-lts_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('unificontroller-lts.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -555,7 +503,6 @@ unificontroller-lts_task:
 
 vault_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('vault.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -564,7 +511,6 @@ vault_task:
 
 weechat_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('weechat.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -573,7 +519,6 @@ weechat_task:
 
 xmrig_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('xmrig.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-11-3
@@ -582,7 +527,6 @@ xmrig_task:
 
 zoneminder_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('zoneminder.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -591,7 +535,6 @@ zoneminder_task:
 
 zrepl_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('zrepl.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-1
@@ -600,7 +543,6 @@ zrepl_task:
 
 zwavejs2mqtt_task:
   <<: *INSTALL_PLUGIN
-  only_if: "changesInclude('zwavejs2mqtt.json')"
   matrix:
     - freebsd_instance:
         image_family: freebsd-12-2

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -83,6 +83,7 @@ install_template: &INSTALL_PLUGIN
     # Cleanup before plugin pkg installation
     pkg delete --yes git-lite git jq
     pkg autoremove --yes
+    pkg clean --yes
 
     echo "Fetching $name pkgs: $pkgs"
     pkg update

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,16 +81,16 @@ install_template: &INSTALL_PLUGIN
       cp -r ./plugin/overlay/ /
     fi
 
-    ./plugin/post_install.sh
+    source ./plugin/post_install.sh
 
     if [ -f ./plugin/pre_update.sh ]
     then
-      ./plugin/pre_update.sh
+      source ./plugin/pre_update.sh
     fi
 
     if [ -f ./plugin/post_update.sh ]
     then
-      ./plugin/post_update.sh
+      source ./plugin/post_update.sh
     fi
 
 backuppc_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,58 +13,60 @@ install_backuppc_task:
     fingerprints=$(jq -r '.fingerprints | keys[]' backuppc.json)
     plugin_repo=$(jq '.artifact' $plugin_file)
 
-#    pkg_dir=/usr/local/test
-#    repos_dir="${pkg_dir}/repos"
-#    fingerprints_dir="${pkg_dir}/fingerprints"
-#
-#    echo "Creating main repos dir: ${repos_dir}"
-#    mkdir -p $repos_dir
-#    export REPOS_DIR=$repos_dir
-#
-#    pkg_conf_path="${repos_dir}/test.conf"
-#    echo "iocage-plugins: {" > $pkg_conf_path
-#    echo "url: $packagesite," >> $pkg_conf_path
-#    echo "signature_type: \"fingerprints\"," >> $pkg_conf_path
-#    echo "fingerprints \"${fingerprints_dir}\"," >> $pkg_conf_path
-#    echo "enabled: true" >> $pkg_conf_path
-#    echo } >> $pkg_conf_path
-#
-#    echo "Created test pkg config file:"
-#    cat $pkg_conf_path
-#
-#    trusted_fingerprints="$fingerprints_dir/trusted"
-#    mkdir -p "${trusted_fingerprints}"
-#
-#    for repo_name in $fingerprints
-#    do
-#      repo_fingerprints=$(jq -rc '."fingerprints"."'${repo_name}'"[]' $plugin_file)
-#
-#      repo_count=1
-#      echo $repo_fingerprints | while IFS='' read f
-#      do
-#        echo "Creating fingerprint file for repo:"
-#        echo $f
-#
-#        function=$(echo $f | jq -r '.function')
-#        fingerprint=$(echo $f | jq -r '.fingerprint')
-#        file_path=${trusted_fingerprints}/${repo_name}_${repo_count}
-#
-#        echo "Creating new fingerprint file: ${file_path}"
-#
-#        echo "function: $function" > ${file_path}
-#        echo "fingerprint: $fingerprint" >> ${file_path}
-#
-#        repo_count=$(expr $repo_count + 1)
-#      done
-#    done
-#
-#    echo "Test install plugin pkgs for plugin: $name"
-#    pkgs=$(jq -r '.pkgs | join(" ")' $plugin_file)
-#    echo "Installing $name pkgs: $pkgs"
-#    pkg install -y $pkgs
-
     pkg install -y ca_root_nss
     plugin_archive=$(echo $plugin_repo | sed 's/\.git/\/archive\/master.zip/')
     fetch ${plugin_archive} plugin.zip
     mkdir plugin
     unzip -d plugin plugin.zip
+
+
+
+    pkg_dir=/usr/local/test
+    repos_dir="${pkg_dir}/repos"
+    fingerprints_dir="${pkg_dir}/fingerprints"
+
+    echo "Creating main repos dir: ${repos_dir}"
+    mkdir -p $repos_dir
+    export REPOS_DIR=$repos_dir
+
+    pkg_conf_path="${repos_dir}/test.conf"
+    echo "iocage-plugins: {" > $pkg_conf_path
+    echo "url: $packagesite," >> $pkg_conf_path
+    echo "signature_type: \"fingerprints\"," >> $pkg_conf_path
+    echo "fingerprints \"${fingerprints_dir}\"," >> $pkg_conf_path
+    echo "enabled: true" >> $pkg_conf_path
+    echo } >> $pkg_conf_path
+
+    echo "Created test pkg config file:"
+    cat $pkg_conf_path
+
+    trusted_fingerprints="$fingerprints_dir/trusted"
+    mkdir -p "${trusted_fingerprints}"
+
+    for repo_name in $fingerprints
+    do
+      repo_fingerprints=$(jq -rc '."fingerprints"."'${repo_name}'"[]' $plugin_file)
+
+      repo_count=1
+      echo $repo_fingerprints | while IFS='' read f
+      do
+        echo "Creating fingerprint file for repo:"
+        echo $f
+
+        function=$(echo $f | jq -r '.function')
+        fingerprint=$(echo $f | jq -r '.fingerprint')
+        file_path=${trusted_fingerprints}/${repo_name}_${repo_count}
+
+        echo "Creating new fingerprint file: ${file_path}"
+
+        echo "function: $function" > ${file_path}
+        echo "fingerprint: $fingerprint" >> ${file_path}
+
+        repo_count=$(expr $repo_count + 1)
+      done
+    done
+
+    echo "Test install plugin pkgs for plugin: $name"
+    pkgs=$(jq -r '.pkgs | join(" ")' $plugin_file)
+    echo "Installing $name pkgs: $pkgs"
+    pkg install -y $pkgs

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ install_backuppc_task:
     name=$(jq '.name' $plugin_file)
     packagesite=$(jq '.packagesite' $plugin_file)
     fingerprints=$(jq -r '.fingerprints | keys[]' backuppc.json)
-    plugin_repo=$(jq '.artifact' $plugin_file)
+    plugin_repo=$(jq -r '.artifact' $plugin_file)
 
     pkg install -y git-lite
     git clone ${plugin_repo} plugin

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[plugins-shield]:https://img.shields.io/badge/TrueNAS%20CORE-Community%20Plugins-blue?logo=TrueNAS&style=for-the-badge
+[plugins-link]:https://www.truenas.com/plugins/
+[release-shield]:https://img.shields.io/badge/Default%20Branch-12.2--RELEASE-blue?logo=FreeBSD&logoColor=red&style=for-the-badge
+[release-link]:https://www.freebsd.org/releases/12.2R/relnotes/
+
+[![x][plugins-shield]][plugins-link] [![x][release-shield]][release-link]
+
 ![Validate JSONs](https://github.com/ix-plugin-hub/iocage-plugin-index/workflows/Validate%20JSONs/badge.svg)
 
 # iocage-ix-plugins

--- a/README.md
+++ b/README.md
@@ -30,118 +30,118 @@ where *interface* is the name of the active network interface and *IP address* i
 For example, `ip4_addr="igb0|192.168.0.91"`
 
 ## Plugin build status
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=backuppc&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=backuppc&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=backuppc&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=backuppc&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bazarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bazarr&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bazarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bazarr&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bind&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bind&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bind&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bind&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=calibre-web&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=calibre-web&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=calibre-web&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=calibre-web&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=channels-dvr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=channels-dvr&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=channels-dvr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=channels-dvr&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=clamav&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=clamav&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=clamav&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=clamav&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=deluge-pip&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=deluge-pip&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=deluge-pip&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=deluge-pip&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=dnsmasq&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=dnsmasq&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=dnsmasq&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=dnsmasq&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=drupal8&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=drupal8&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=drupal8&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=drupal8&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=duplicati&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=duplicati&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=duplicati&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=duplicati&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby-server-stable&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby-server-stable&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby-server-stable&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby-server-stable&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=esphome&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=esphome&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=esphome&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=esphome&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=famp&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=famp&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=famp&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=famp&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitea&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitea&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitea&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitea&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitlab&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitlab&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitlab&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitlab&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gogs&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gogs&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gogs&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gogs&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=grafana&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=grafana&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=grafana&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=grafana&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=heimdall-dashboard&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=heimdall-dashboard&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=heimdall-dashboard&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=heimdall-dashboard&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homeassistant&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homeassistant&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homeassistant&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homeassistant&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homebridge&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homebridge&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homebridge&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homebridge&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=hoobs&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=hoobs&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=hoobs&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=hoobs&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=i2p&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=i2p&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=i2p&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=i2p&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=irssi&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=irssi&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=irssi&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=irssi&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jackett&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jackett&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jackett&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jackett&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins-lts&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins-lts&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins-lts&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins-lts&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=lidarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=lidarr&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=lidarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=lidarr&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=madsonic&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=madsonic&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=madsonic&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=madsonic&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mineos&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mineos&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mineos&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mineos&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=monica&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=monica&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=monica&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=monica&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mosquitto&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mosquitto&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mosquitto&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mosquitto&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=motioneye&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=motioneye&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=motioneye&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=motioneye&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=netdata&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=netdata&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=netdata&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=netdata&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=node-red&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=node-red&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=node-red&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=node-red&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=nzbget&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=nzbget&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=nzbget&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=nzbget&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openspeedtest-server&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openspeedtest-server&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openspeedtest-server&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openspeedtest-server&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openvpn&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openvpn&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openvpn&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openvpn&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=privatebin&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=privatebin&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=privatebin&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=privatebin&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=qbittorrent&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=qbittorrent&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=qbittorrent&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=qbittorrent&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=quasselcore&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=quasselcore&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=quasselcore&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=quasselcore&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=radarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=radarr&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=radarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=radarr&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rslsync&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rslsync&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rslsync&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rslsync&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rtorrent-flood&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rtorrent-flood&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rtorrent-flood&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rtorrent-flood&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sabnzbd&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sabnzbd&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sabnzbd&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sabnzbd&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sickchill&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sickchill&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sickchill&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sickchill&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sonarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sonarr&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sonarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sonarr&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tasmoadmin&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tasmoadmin&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tasmoadmin&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tasmoadmin&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tautulli&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tautulli&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tautulli&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tautulli&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=transmission&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=transmission&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=transmission&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=transmission&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller-lts&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller-lts&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller-lts&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller-lts&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=vault&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=vault&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=vault&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=vault&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=weechat&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=weechat&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=weechat&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=weechat&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=xmrig&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=xmrig&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=xmrig&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=xmrig&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zoneminder&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zoneminder&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zoneminder&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zoneminder&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zrepl&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zrepl&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zrepl&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zrepl&branch=master)
 
-[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=master>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=master)

--- a/README.md
+++ b/README.md
@@ -28,3 +28,120 @@ iocage fetch -P jenkins -g https://github.com/ix-plugin-hub/iocage-plugin-index 
 </pre>
 where *interface* is the name of the active network interface and *IP address* is the desired IP address for the plugin.
 For example, `ip4_addr="igb0|192.168.0.91"`
+
+## Plugin build status
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_backuppc&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_backuppc&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bazarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bazarr&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bind&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bind&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_calibre-web&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_calibre-web&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_channels-dvr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_channels-dvr&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_clamav&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_clamav&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_deluge-pip&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_deluge-pip&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_dnsmasq&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_dnsmasq&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_drupal8&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_drupal8&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_duplicati&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_duplicati&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby-server-stable&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby-server-stable&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_esphome&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_esphome&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_famp&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_famp&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitea&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitea&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitlab&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitlab&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gogs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gogs&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_grafana&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_grafana&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_heimdall-dashboard&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_heimdall-dashboard&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homeassistant&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homeassistant&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homebridge&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homebridge&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_hoobs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_hoobs&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_i2p&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_i2p&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_irssi&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_irssi&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jackett&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jackett&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins-lts&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_lidarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_lidarr&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_madsonic&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_madsonic&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mineos&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mineos&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_monica&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_monica&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mosquitto&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mosquitto&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_motioneye&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_motioneye&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_netdata&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_netdata&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_node-red&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_node-red&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_nzbget&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_nzbget&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openspeedtest-server&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openspeedtest-server&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openvpn&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openvpn&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_privatebin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_privatebin&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_qbittorrent&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_qbittorrent&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_quasselcore&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_quasselcore&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_radarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_radarr&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rslsync&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rslsync&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rtorrent-flood&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rtorrent-flood&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sabnzbd&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sabnzbd&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sickchill&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sickchill&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sonarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sonarr&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tasmoadmin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tasmoadmin&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tautulli&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tautulli&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_transmission&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_transmission&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller-lts&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_vault&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_vault&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_weechat&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_weechat&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_xmrig&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_xmrig&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zoneminder&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zoneminder&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zrepl&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zrepl&branch=test-install-plugins>)
+
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zwavejs2mqtt&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zwavejs2mqtt&branch=test-install-plugins>)

--- a/README.md
+++ b/README.md
@@ -30,118 +30,118 @@ where *interface* is the name of the active network interface and *IP address* i
 For example, `ip4_addr="igb0|192.168.0.91"`
 
 ## Plugin build status
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_backuppc&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_backuppc&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=backuppc&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=backuppc&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bazarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bazarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bazarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bazarr&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bind&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_bind&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bind&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bind&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_calibre-web&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_calibre-web&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=calibre-web&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=calibre-web&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_channels-dvr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_channels-dvr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=channels-dvr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=channels-dvr&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_clamav&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_clamav&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=clamav&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=clamav&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_deluge-pip&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_deluge-pip&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=deluge-pip&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=deluge-pip&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_dnsmasq&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_dnsmasq&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=dnsmasq&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=dnsmasq&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_drupal8&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_drupal8&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=drupal8&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=drupal8&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_duplicati&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_duplicati&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=duplicati&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=duplicati&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby-server-stable&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_emby-server-stable&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby-server-stable&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby-server-stable&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_esphome&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_esphome&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=esphome&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=esphome&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_famp&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_famp&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=famp&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=famp&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitea&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitea&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitea&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitea&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitlab&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gitlab&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitlab&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitlab&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gogs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_gogs&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gogs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gogs&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_grafana&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_grafana&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=grafana&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=grafana&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_heimdall-dashboard&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_heimdall-dashboard&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=heimdall-dashboard&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=heimdall-dashboard&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homeassistant&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homeassistant&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homeassistant&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homeassistant&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homebridge&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_homebridge&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homebridge&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homebridge&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_hoobs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_hoobs&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=hoobs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=hoobs&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_i2p&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_i2p&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=i2p&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=i2p&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_irssi&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_irssi&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=irssi&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=irssi&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jackett&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jackett&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jackett&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jackett&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_jenkins-lts&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins-lts&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_lidarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_lidarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=lidarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=lidarr&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_madsonic&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_madsonic&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=madsonic&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=madsonic&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mineos&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mineos&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mineos&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mineos&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_monica&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_monica&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=monica&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=monica&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mosquitto&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_mosquitto&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mosquitto&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mosquitto&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_motioneye&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_motioneye&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=motioneye&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=motioneye&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_netdata&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_netdata&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=netdata&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=netdata&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_node-red&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_node-red&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=node-red&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=node-red&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_nzbget&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_nzbget&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=nzbget&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=nzbget&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openspeedtest-server&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openspeedtest-server&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openspeedtest-server&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openspeedtest-server&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openvpn&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_openvpn&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openvpn&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openvpn&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_privatebin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_privatebin&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=privatebin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=privatebin&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_qbittorrent&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_qbittorrent&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=qbittorrent&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=qbittorrent&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_quasselcore&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_quasselcore&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=quasselcore&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=quasselcore&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_radarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_radarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=radarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=radarr&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rslsync&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rslsync&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rslsync&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rslsync&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rtorrent-flood&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_rtorrent-flood&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rtorrent-flood&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rtorrent-flood&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sabnzbd&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sabnzbd&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sabnzbd&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sabnzbd&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sickchill&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sickchill&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sickchill&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sickchill&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sonarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_sonarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sonarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sonarr&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tasmoadmin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tasmoadmin&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tasmoadmin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tasmoadmin&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tautulli&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_tautulli&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tautulli&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tautulli&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_transmission&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_transmission&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=transmission&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=transmission&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_unificontroller-lts&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller-lts&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_vault&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_vault&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=vault&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=vault&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_weechat&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_weechat&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=weechat&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=weechat&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_xmrig&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_xmrig&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=xmrig&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=xmrig&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zoneminder&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zoneminder&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zoneminder&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zoneminder&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zrepl&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zrepl&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zrepl&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zrepl&branch=test-install-plugins>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zwavejs2mqtt&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=install_zwavejs2mqtt&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=test-install-plugins>)

--- a/README.md
+++ b/README.md
@@ -30,118 +30,118 @@ where *interface* is the name of the active network interface and *IP address* i
 For example, `ip4_addr="igb0|192.168.0.91"`
 
 ## Plugin build status
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=backuppc&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=backuppc&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=backuppc&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=backuppc&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bazarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bazarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bazarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bazarr&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bind&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=bind&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bind&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=bind&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=calibre-web&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=calibre-web&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=calibre-web&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=calibre-web&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=channels-dvr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=channels-dvr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=channels-dvr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=channels-dvr&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=clamav&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=clamav&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=clamav&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=clamav&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=deluge-pip&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=deluge-pip&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=deluge-pip&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=deluge-pip&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=dnsmasq&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=dnsmasq&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=dnsmasq&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=dnsmasq&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=drupal8&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=drupal8&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=drupal8&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=drupal8&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=duplicati&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=duplicati&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=duplicati&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=duplicati&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby-server-stable&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=emby-server-stable&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby-server-stable&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=emby-server-stable&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=esphome&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=esphome&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=esphome&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=esphome&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=famp&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=famp&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=famp&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=famp&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitea&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitea&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitea&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitea&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitlab&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gitlab&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitlab&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gitlab&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gogs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=gogs&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gogs&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=gogs&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=grafana&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=grafana&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=grafana&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=grafana&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=heimdall-dashboard&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=heimdall-dashboard&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=heimdall-dashboard&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=heimdall-dashboard&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homeassistant&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homeassistant&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homeassistant&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homeassistant&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homebridge&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=homebridge&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homebridge&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=homebridge&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=hoobs&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=hoobs&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=hoobs&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=hoobs&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=i2p&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=i2p&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=i2p&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=i2p&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=irssi&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=irssi&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=irssi&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=irssi&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jackett&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jackett&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jackett&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jackett&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=jenkins-lts&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins-lts&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=jenkins-lts&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=lidarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=lidarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=lidarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=lidarr&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=madsonic&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=madsonic&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=madsonic&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=madsonic&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mineos&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mineos&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mineos&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mineos&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=monica&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=monica&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=monica&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=monica&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mosquitto&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=mosquitto&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mosquitto&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=mosquitto&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=motioneye&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=motioneye&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=motioneye&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=motioneye&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=netdata&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=netdata&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=netdata&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=netdata&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=node-red&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=node-red&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=node-red&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=node-red&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=nzbget&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=nzbget&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=nzbget&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=nzbget&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openspeedtest-server&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openspeedtest-server&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openspeedtest-server&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openspeedtest-server&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openvpn&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=openvpn&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openvpn&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=openvpn&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=privatebin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=privatebin&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=privatebin&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=privatebin&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=qbittorrent&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=qbittorrent&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=qbittorrent&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=qbittorrent&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=quasselcore&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=quasselcore&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=quasselcore&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=quasselcore&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=radarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=radarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=radarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=radarr&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rslsync&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rslsync&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rslsync&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rslsync&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rtorrent-flood&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=rtorrent-flood&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rtorrent-flood&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=rtorrent-flood&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sabnzbd&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sabnzbd&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sabnzbd&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sabnzbd&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sickchill&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sickchill&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sickchill&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sickchill&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sonarr&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=sonarr&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sonarr&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=sonarr&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tasmoadmin&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tasmoadmin&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tasmoadmin&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tasmoadmin&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tautulli&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=tautulli&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tautulli&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=tautulli&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=transmission&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=transmission&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=transmission&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=transmission&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller-lts&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=unificontroller-lts&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller-lts&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=unificontroller-lts&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=vault&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=vault&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=vault&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=vault&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=weechat&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=weechat&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=weechat&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=weechat&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=xmrig&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=xmrig&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=xmrig&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=xmrig&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zoneminder&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zoneminder&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zoneminder&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zoneminder&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zrepl&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zrepl&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zrepl&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zrepl&branch=master>)
 
-[![Build Status](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=test-install-plugins)](https://api.cirrus-ci.com/github/fulder/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=test-install-plugins>)
+[![Build Status](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=master)](https://api.cirrus-ci.com/github/ix-plugin-hub/iocage-plugin-index.svg?task=zwavejs2mqtt&branch=master>)

--- a/backuppc.json
+++ b/backuppc.json
@@ -1,6 +1,6 @@
 {
     "name": "BackupPC",
-    "release": "12.2-RELEASE",
+    "release": "12.1-RELEASE",
     "official": false,
     "artifact": "https://github.com/freenas/iocage-plugin-backuppc.git",
     "properties": {

--- a/backuppc.json
+++ b/backuppc.json
@@ -16,7 +16,7 @@
         "iocage-plugins": [
             {
                 "function": "sha256",
-                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438123"
+                "fingerprint": "b0170035af3acc5f3f3ae1859dc717101b4e6c1d0a794ad554928ca0cbb2f438"
             }
         ]
     },

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,3 +5,5 @@ Please ensure the following guidelines are met when submitting a new Plugin.
 1. Add the entry to INDEX in alphabetical order
 2. Includes a new icon in the ./icon/ directory
 3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
+4. Add new plugin cirrus task
+5. Update `README.md` "Plugin build status" section with new task badge


### PR DESCRIPTION
Add Cirrus CI tasks for testing installation of all plugins in this repository. 

The main reason and motivation for this PR and implementation is to get an overview of working and non-working plugins in this repository without being forced to test it manually or wait for issues from users (e.g. running a newer version of FreeBSD). This will also make it easier to know if updating a lot of plugins at the same time (for example when EoL of FreeBSD/plugin is reached and the release/artifacts updated) doesn't break anything for the end users during updates.

Except from installation feedback, these tests also give feedback about how long time it takes to install a plugin. This can be useful in order to optimize and minimize the installation progress (as an example: I have already noticed I installed `git` instead of `git-lite` in some of my plugins) 

I started out trying to implement this using GitHub actions but as there aren't any good VMs for FreeBSD (except for the MacOS VM one taking long time to boot up as well as only supporting 2 latest FreeBSD versions: https://github.com/marketplace/actions/freebsd-vm) I switched to Cirrus CI, it has support for a lot of different FreeBSD versions (out of the box): https://cirrus-ci.org/guide/FreeBSD/#list-of-available-image-families.

Furthermore, during the sh task implementation I realized it got more and more alike another "iocage plugin implementation" (although much more hardcoded than that). It would probably work OK to simply install the iocage from `pkg`, but as it does have a lot of own package dependencies it could make the tests less accurate (as forgetting a plugin dependency being available in iocage dependencies would be missed), as well as an `iocage` update/bug could make the tests fail incorrectly. That said testing `iocage` CLI at the same time doesn't feel fit for this repository and would probably be done better in the official `iocage` repo.

This PR will run cirrus task for all currently available plugins, this is done only during the initial/first implementation of this pipeline in order to get a first/initial build status for all the plugins and the master branch. Running all tasks all the time is a bad idea (especially if no plugins have been added/updated) to do for every following PR due to long run time and Free Cirrus public github repositories limitations: https://cirrus-ci.org/faq/#are-there-any-limits. A new PR will follow if/after this gets merged only running plugin tasks on changes.

If you decide to merge this PR (or enable the run from this PR), this repo will need to get the Cirrus CI github plugin installed. See official quickstart guide here for the (simple) required steps: https://cirrus-ci.org/guide/quick-start/

I've tried to install it on my own fork, see latest builds: https://cirrus-ci.com/github/fulder/iocage-plugin-index

There are currently a few plugins already failing in these tests because of different kind of errors (FreeBSD EoL, invalid packages/versions, no longer maintained plugins), I have another branch fixing the most common errors (which should probably solve some of the currently open issues in this repo). But IMO it should be OK to merge this although the check is failing and fix the errors in new PRs one at a time by/with support from plugin owners.