### PR TITLE
Update emby-server-stable.json

### DIFF
--- a/emby-server-stable.json
+++ b/emby-server-stable.json
@@ -6,9 +6,7 @@
         "dhcp": 1,
         "allow_raw_sockets": "1"
     },
-    "pkgs": [
-        "emby-server",
-        "ffmpeg",
+    "pkgs": [        
         "mono",
         "libass",
         "fontconfig",
@@ -22,13 +20,15 @@
         "libva",
         "libvpx",
         "libvorbis",
+        "ocl-icd",
         "webp",
         "libx264",
         "x265",
         "dav1d",
         "libzvbi",
         "libraw",
-        "ImageMagick6"
+        "ImageMagick6",
+        "emby-server"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Moved emby-server to end of pkg list so that custom version of ffmpeg is not overwritten by standard pkg. Removed standard pkg from list.

Per bug report and troubleshooting at: https://emby.media/community/index.php?/topic/94866-can-i-limit-transcoding-fps/&do=findComment&comment=990843
