### PR TITLE
Update emby.json

### DIFF
--- a/emby.json
+++ b/emby.json
@@ -1,6 +1,6 @@
 {
     "name": "Emby",
-    "release": "12.1-RELEASE",
+    "release": "12.2-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
     "official": false,
     "properties": {
@@ -9,7 +9,6 @@
     },
     "pkgs": [
         "emby-server",
-        "ffmpeg"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {
@@ -20,5 +19,5 @@
             }
         ]
     },
-    "revision": "0"
+    "revision": "1"
 }


### PR DESCRIPTION
removing standard pkg ffmpeg as it is causing issues with Emby transcoding throttling feature per bug report and troubleshooting at: https://emby.media/community/index.php?/topic/94866-can-i-limit-transcoding-fps/&do=findComment&comment=990843
