### PR TITLE
Fix emby plugin manifest JSON syntax

### DIFF
--- a/emby.json
+++ b/emby.json
@@ -8,7 +8,7 @@
         "nat_forwards": "tcp(8096:8096)"
     },
     "pkgs": [
-        "emby-server",
+        "emby-server"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Fix invalid JSON syntax i `emby` plugin manifest.

---

Pretty funny there was a PR (https://github.com/ix-plugin-hub/iocage-plugin-index/pull/173) merged just before my plugin tests one making the `emby` tests fail after merge into `master`. I saw this plugin passing over and over again during testing on my "old" branch.

There was an extra comma left over in the manifest, really easy to miss these kind of things and yet another example where these automatic tests will be a great help (I hope :crossed_fingers:)