### PR TITLE
Add missing plugin tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -100,7 +100,7 @@ emby_task:
   only_if: "changesInclude('emby.json', '.cirrus/install_script.sh')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "emby.json"
 
@@ -355,6 +355,15 @@ openvpn_task:
         image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "openvpn.json"
+
+piwigo_task:
+  <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('piwigo.json', '.cirrus/install_script.sh')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+  env:
+    PLUGIN_FILE: "piwigo.json"
 
 privatebin_task:
   <<: *INSTALL_PLUGIN

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -302,6 +302,15 @@ motioneye_task:
   env:
     PLUGIN_FILE: "motioneye.json"
 
+movienight_task:
+  <<: *INSTALL_PLUGIN
+  only_if: "changesInclude('movienight.json', '.cirrus/install_script.sh')"
+  matrix:
+    - freebsd_instance:
+        image_family: freebsd-12-2
+  env:
+    PLUGIN_FILE: "movienight.json"
+
 netdata_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('netdata.json', '.cirrus/install_script.sh')"


### PR DESCRIPTION
During the first test implementation there were 2 new plugins merged into master which were missed in the new cirrus file. Have added them in this PR.

Also synced `emby` plugin to match the plugin manifest version.