### PR TITLE
Add dependency to deluge

### DIFF
--- a/deluge-pip.json
+++ b/deluge-pip.json
@@ -13,6 +13,7 @@
         "py37-pip",
         "py37-pillow",
         "py37-libtorrent-rasterbar",
+        "libtorrent-rasterbar",
         "rust"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",


### PR DESCRIPTION
I'm not very sure about this, but the daemon didn't start (could not find the libtorrent lib) until this dependency was installed.

Hopefully @jsegaert can shed some light.