### PR TITLE
Upgrade gitlab postgres and FreeBSD version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -145,7 +145,7 @@ gitlab_task:
   only_if: "changesInclude('gitlab.json', '.cirrus/install_script.sh')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "gitlab.json"
 

--- a/gitlab.json
+++ b/gitlab.json
@@ -4,9 +4,9 @@
   "artifact": "https://github.com/pandorixtech/iocage-plugin-gitlab.git",
   "pkgs": [
     "gitlab-ce",
-    "postgresql11-server",
-    "postgresql11-contrib",
-    "postgresql11-client",
+    "postgresql12-server",
+    "postgresql12-contrib",
+    "postgresql12-client",
     "nginx",
     "gtar"
   ],

--- a/gitlab.json
+++ b/gitlab.json
@@ -1,11 +1,11 @@
 {
   "name": "GitLab",
-  "release": "12.1-RELEASE",
+  "release": "12.2-RELEASE",
   "artifact": "https://github.com/pandorixtech/iocage-plugin-gitlab.git",
   "pkgs": [
     "gitlab-ce",
-    "postgresql12-server",
-    "postgresql12-contrib",
+    "postgresql11-server",
+    "postgresql11-contrib",
     "nginx",
     "gtar"
   ],

--- a/gitlab.json
+++ b/gitlab.json
@@ -4,8 +4,8 @@
   "artifact": "https://github.com/pandorixtech/iocage-plugin-gitlab.git",
   "pkgs": [
     "gitlab-ce",
-    "postgresql11-server",
-    "postgresql11-contrib",
+    "postgresql12-server",
+    "postgresql12-contrib",
     "nginx",
     "gtar"
   ],

--- a/gitlab.json
+++ b/gitlab.json
@@ -6,7 +6,6 @@
     "gitlab-ce",
     "postgresql12-server",
     "postgresql12-contrib",
-    "postgresql12-client",
     "nginx",
     "gtar"
   ],


### PR DESCRIPTION
Gitlab plugin is currently broken, see related issues: https://github.com/ix-plugin-hub/iocage-plugin-index/issues/118, https://github.com/freenas/iocage-plugin-gitlab/issues/11

Because the `gitlab-ce` package depends on postgres 12 client the postgres 11 is uninstalled which makes the post_install script fail.

Installing a DB "bundled" together in the same jail as the actual server can feel a unsecure as re-installing the plugin will reinstall the database? (Hopefully not touching the db files)Would probably be more safe to have the database in another jail and/or implement a pre/post update in the plugin repository taking a backup and restoring the database after. But this PR should probably at least fix the clean installation issues.

Also bumping jail version to 12.2 as 12.1 is EoL.