### PR TITLE
Up Heimdall to 12.2-RELEASE

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -172,7 +172,7 @@ heimdall-dashboard_task:
   only_if: "changesInclude('heimdall-dashboard.json', '.cirrus/install_script.sh')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "heimdall-dashboard.json"
 

--- a/heimdall-dashboard.json
+++ b/heimdall-dashboard.json
@@ -1,7 +1,7 @@
 {
     "name": "heimdall-dashboard",
     "plugin_schema": "2",
-    "release": "12.1-RELEASE",
+    "release": "12.2-RELEASE",
     "artifact": "https://github.com/jsegaert/iocage-plugin-heimdall.git",
     "properties": {
         "dhcp":"1"


### PR DESCRIPTION
This updates the Heimdall-dashboard plugin to 12.2-RELEASE

- [x] Manually tested on TrueNAS CORE 12.0-U2.1
- [x] Updated Cirrus CI task to 12-2
