### PR TITLE
back to py27 as motioneye doesn't support py3 yet.

### DIFF
--- a/motioneye.json
+++ b/motioneye.json
@@ -9,8 +9,8 @@
         "nat_forwards": "tcp(8765:8765)"
     },
     "pkgs": [
-        "python37",
-        "py37-pip",
+        "python27",
+        "py27-pip",
         "motion",
         "ffmpeg",
         "v4l-utils",


### PR DESCRIPTION
I know python2.7 is deprecated but motioneye isn't functional yet on python3 (https://github.com/ccrisan/motioneye/pulls)
The only official support is through python2.7 and this change makes the installer functional again. If it is against some kind of rules to use deprecated packages, than the plugin installer should be considered broken and removed while the python3 compatibility is being finished.

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task