### PR TITLE
Upgrade unifi

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -460,7 +460,7 @@ unificontroller_task:
   only_if: "changesInclude('unificontroller.json', '.cirrus/install_script.sh')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-11-3
+        image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "unificontroller.json"
 

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -7,7 +7,7 @@
         "nat_forwards": "tcp(8443:8444),udp(3478:3478),tcp(8080:8080),tcp(6789:6789),udp(10001:10001),udp(1900:1900)"
     },
     "pkgs": [
-        "unifi5"
+        "unifi6"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {

--- a/unificontroller.json
+++ b/unificontroller.json
@@ -1,6 +1,6 @@
 {
     "name": "unificontroller",
-    "release": "11.3-RELEASE",
+    "release": "12.2-RELEASE",
     "artifact": "https://github.com/lbalker/iocage-plugin-unificontroller.git",
     "properties": {
         "nat": 1,


### PR DESCRIPTION
Looks like unifi6 has been released for other FreeBSD versions than only 14 some days ago: https://www.freshports.org/net-mgmt/unifi6/. Hopefully it should be fine to upgrade the package for this plugin now as well. 

Also upgraded the jail version from 11.3 to 12.2.