### PR TITLE
Check service status in cirrus tests

### DIFF
--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -12,12 +12,12 @@ check_service_status()
 
   echo "${services_after}" | while IFS=' ' read -r a
   do
-    if echo "${services_before}" | grep "$a"
+    if echo "${services_before}" | grep "${a}"
     then
       echo "Skip checking service $a, was enabled before post_install"
     else
       echo "Checking if service $a is running"
-      service $a status
+      service "${a}" status
     fi
   done
 }

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -12,10 +12,8 @@ check_service_status()
 
   echo "${services_after}" | while IFS=' ' read -r a
   do
-    if echo "${services_before}" | grep "${a}"
+    if ! echo "${services_before}" | grep "${a}"
     then
-      echo "Skip checking service $a, was enabled before post_install"
-    else
       echo "Checking if service $a is running"
       service "${a}" status
     fi

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -12,7 +12,7 @@ check_service_status()
 
   echo "${services_after}" | while IFS=' ' read -r a
   do
-    if ! echo "${services_before}" | grep "${a}"
+    if ! echo "${services_before}" | grep -q "${a}"
     then
       echo "Checking if service $a is running"
       service "${a}" status

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -15,7 +15,7 @@ check_service_status()
     if ! echo "${services_before}" | grep -q "${a}"
     then
       echo "Checking if service $a is running"
-      service "${a}" status
+      "${a}" status
     fi
   done
 }

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -12,19 +12,10 @@ check_service_status()
 
   echo "${services_after}" | while IFS=' ' read -r a
   do
-    check_service=true
-    echo "${services_before}" | while IFS=' ' read -r b
-    do
-      if [ "$a" = "$b" ]
-      then
-        echo "Skip checking service $a, was enabled before post_install"
-        check_service=false
-        break
-      fi
-    done
-
-    if ${check_service}
+    if echo "${services_before}" | grep "$a"
     then
+      echo "Skip checking service $a, was enabled before post_install"
+    else
       echo "Checking if service $a is running"
       service $a status
     fi

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -11,7 +11,7 @@ wait_for_services()
 
   echo $post_install_services | while IFS='' read s
   do
-    serivce $s status
+    service $s status
   done
 }
 

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -3,6 +3,18 @@ set -e
 
 pkg install --yes jq
 
+wait_for_services()
+{
+  post_install_path=${1}
+  post_install_services=$(cat ${post_install_path} | grep -E "service.*start" | cut -d" " -f2)
+  echo "Checking if post install services are running: ${post_install_services}"
+
+  echo $post_install_services | while IFS='' read s
+  do
+    serivce $s status
+  done
+}
+
 release=$(jq -r '.release' $PLUGIN_FILE)
 name=$(jq '.name' $PLUGIN_FILE)
 packagesite=$(jq '.packagesite' $PLUGIN_FILE)
@@ -97,6 +109,8 @@ then
 fi
 
 ${plugin_dir}/post_install.sh
+
+wait_for_services "${plugin_dir}/post_install.sh"
 
 if [ -f ${plugin_dir}/pre_update.sh ] && ! [ -x ${plugin_dir}/pre_update.sh ]
 then


### PR DESCRIPTION
Add extra check to plugin installation tests validating if services started during `post_install` script execution are up and running (using `status`).

The implementation checks current services using `service -e` before and after post_install is run and then runs `status` on the `rc.d` scripts which weren't included in the initial `service -e` run.

The main reason for this extra check was the false positive test results where both the post_install script passed as well as the UI was reachable, although there was something wrong with the running service making it fail during a more complicated use case (for example using the UI more than just reaching it). Good examples of such false positive test is the `deluge-pip` plugin, test run: https://cirrus-ci.com/task/4527133297999872 (related PR/issue: https://github.com/ix-plugin-hub/iocage-plugin-index/pull/184).
