### PR TITLE
Ignore services check support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -537,6 +537,7 @@ zrepl_task:
         image_family: freebsd-12-1
   env:
     PLUGIN_FILE: "zrepl.json"
+    SKIP_SERVICE_CHECK: "true"
 
 zwavejs2mqtt_task:
   <<: *INSTALL_PLUGIN

--- a/.cirrus/install_script.sh
+++ b/.cirrus/install_script.sh
@@ -211,8 +211,11 @@ print_info "Executing post_install.sh script"
 ${plugin_dir}/post_install.sh
 print_success "Post install complete"
 
-services_after=$(service -e)
-check_service_status "${services_before}" "${services_after}"
+if [ "$SKIP_SERVICE_CHECK" != "true" ]
+then
+  services_after=$(service -e)
+  check_service_status "${services_before}" "${services_after}"
+fi
 
 print_info "Disable plugins pkg repos"
 unset REPOS_DIR


### PR DESCRIPTION
Add new env var: `SKIP_SERVICE_CHECK` for skipping service check for plugin tests. 

A plugin example where this is needed is the `zerpl` plugin containing a config file which should be edited by the user. Before that is done the service won't start correctly. For more info see the `post_install` text in the plugin repo: https://github.com/johnramsden/iocage-plugin-zrepl/blob/master/post_install.sh#L25