### PR TITLE
Change git to git-lite for bazarr plugin

### DIFF
--- a/bazarr.json
+++ b/bazarr.json
@@ -9,7 +9,7 @@
     "py37-libxml2",
     "py37-sqlite3",
     "libxslt",
-    "git",
+    "git-lite",
     "unrar",
     "ffmpeg"
   ],


### PR DESCRIPTION
Minor package change for `bazarr` plugin from `git` to `git-lite`. It is only used for a `git clone` command inside the `post_install` script so should speed up a fresh install a bit.