### PR TITLE
Update emby.json with https port in NAT

### DIFF
--- a/emby.json
+++ b/emby.json
@@ -5,7 +5,7 @@
     "official": false,
     "properties": {
         "nat": 1,
-        "nat_forwards": "tcp(8096:8096)","tcp(8920:8920)"
+        "nat_forwards": "tcp(8096:8096),tcp(8920:8920)"
     },
     "pkgs": [
         "emby-server"

--- a/emby.json
+++ b/emby.json
@@ -1,11 +1,11 @@
 {
-    "name": "Emby",
+    "name": "Emby NAT Server",
     "release": "12.2-RELEASE",
     "artifact": "https://github.com/freenas/iocage-plugin-emby.git",
     "official": false,
     "properties": {
         "nat": 1,
-        "nat_forwards": "tcp(8096:8096)"
+        "nat_forwards": "tcp(8096:8096)","tcp(8920:8920)"
     },
     "pkgs": [
         "emby-server"
@@ -19,5 +19,5 @@
             }
         ]
     },
-    "revision": "1"
+    "revision": "2"
 }


### PR DESCRIPTION
adding the https port per: https://support.emby.media/support/solutions/articles/44001159258-advanced-menu to the NAT_Forwards. Changing the name to reflect the difference between this and the other port.

I would like to hear comments about making this the beta channel plug-in to make it usefully different from the other emby plug-in?

Thank you for your submission to the FreeNAS community plugins repository!