### PR TITLE
Update emby.json with ffmpeg fix

### DIFF
--- a/emby.json
+++ b/emby.json
@@ -8,7 +8,8 @@
         "nat_forwards": "tcp(8096:8096)"
     },
     "pkgs": [
-        "emby-server"
+        "emby-server",
+        "ffmpeg"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {
@@ -19,5 +20,5 @@
             }
         ]
     },
-    "revision": "1"
+    "revision": "2"
 }


### PR DESCRIPTION
Re-adding ffmpeg to fix transcoding errors until the artifact.git can be redirected to use emby_servers custom FFMPEG build. https://github.com/freenas/iocage-plugin-emby/pull/5 is pending and once it is pushed ffmpeg can be removed from the plugin json.

This will repair the following issues: https://www.truenas.com/community/threads/emby-new-movies-not-playable-after-upgrade-to-truenas-12.92303/ and https://www.truenas.com/community/threads/emby-plugin-no-playback-error.71961/ and and others on the emby forum.