### PR TITLE
fixing transcoding for now

### DIFF
--- a/emby-server-stable.json
+++ b/emby-server-stable.json
@@ -28,6 +28,7 @@
         "libzvbi",
         "libraw",
         "ImageMagick6",
+        "ffmpeg",
         "emby-server"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
@@ -39,6 +40,6 @@
             }
         ]
     },
-    "revision": "0",
+    "revision": "1",
     "official": false
 }


### PR DESCRIPTION
Re-adding ffmpeg to fix transcoding errors until the artifact.git can be redirected to use emby_servers custom FFMPEG build. https://github.com/freenas/iocage-plugin-emby/pull/5 is pending and once it is pushed ffmpeg can be removed from the plugin json.

This will repair the following issues: https://www.truenas.com/community/threads/emby-new-movies-not-playable-after-upgrade-to-truenas-12.92303/ and https://www.truenas.com/community/threads/emby-plugin-no-playback-error.71961/ and and others on the emby forum.