### PR TITLE
Update emby.json with ffmpeg fix and https NAT port

### DIFF
--- a/emby.json
+++ b/emby.json
@@ -5,7 +5,7 @@
     "official": false,
     "properties": {
         "nat": 1,
-        "nat_forwards": "tcp(8096:8096)"
+        "nat_forwards": "tcp(8096:8096),tcp(8920:8920)"
     },
     "pkgs": [
         "emby-server",

--- a/emby.json
+++ b/emby.json
@@ -8,7 +8,8 @@
         "nat_forwards": "tcp(8096:8096)"
     },
     "pkgs": [
-        "emby-server"
+        "emby-server",
+        "ffmpeg"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Re-adding ffmpeg to fix transcoding errors until the artifact.git can be redirected to use emby_servers custom FFMPEG build. https://github.com/freenas/iocage-plugin-emby/pull/5 is pending and once it is pushed ffmpeg can be removed from the plugin json.

This will repair the following issues: https://www.truenas.com/community/threads/emby-new-movies-not-playable-after-upgrade-to-truenas-12.92303/ and https://www.truenas.com/community/threads/emby-plugin-no-playback-error.71961/ and and others on the emby forum.

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task