### PR TITLE
Upgrade rdiff-backup to Python 3.8

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -12,12 +12,12 @@
         "nat_forwards": "tcp(8443:8443),tcp(25565:25565),tcp(25566:25566),tcp(25567:25567),tcp(25568:25568),tcp(25569:25569),tcp(25570:25570)"
     },
     "pkgs": [
-        "py37-rdiff-backup",
+        "py38-rdiff-backup",
         "screen",
         "rsync",
         "gmake",
         "git-lite",
-        "python37",
+        "python38",
         "node",
         "npm",
         "openjdk11-jre",


### PR DESCRIPTION
The `rdiff-backup` package moved on to Python 3.8 in the latest branch, and this broke the MineOS plugin, as reported here:
https://www.truenas.com/community/threads/mineos-plugin-install-error-py37-rdiff-backup-failed-to-install.92941/

This PR addresses this issue.

Thank you!

