### PR TITLE
deluge-pip upgraded to python 3.8

### DIFF
--- a/deluge-pip.json
+++ b/deluge-pip.json
@@ -2,7 +2,7 @@
     "name": "deluge-pip",
     "plugin_schema": "2",
     "release": "12.2-RELEASE",
-    "artifact": "https://github.com/jsegaert/iocage-plugin-deluge-pip.git",
+    "artifact": "https://github.com/Richardgriff/iocage-plugin-deluge-pip.git",
     "properties": {
         "nat": "1",
         "nat_forwards": "tcp(8112:8112)"

--- a/deluge-pip.json
+++ b/deluge-pip.json
@@ -25,4 +25,4 @@
         ]
     },
     "official": false
-}
+} 

--- a/deluge-pip.json
+++ b/deluge-pip.json
@@ -2,7 +2,7 @@
     "name": "deluge-pip",
     "plugin_schema": "2",
     "release": "12.2-RELEASE",
-    "artifact": "https://github.com/Richardgriff/iocage-plugin-deluge-pip.git",
+    "artifact": "https://github.com/jsegaert/iocage-plugin-deluge-pip.git",
     "properties": {
         "nat": "1",
         "nat_forwards": "tcp(8112:8112)"

--- a/deluge-pip.json
+++ b/deluge-pip.json
@@ -9,10 +9,10 @@
     },
     "pkgs": [
         "ca_root_nss",
-        "python37",
-        "py37-pip",
-        "py37-pillow",
-        "py37-libtorrent-rasterbar",
+        "python38",
+        "py38-pip",
+        "py38-pillow",
+        "py38-libtorrent-rasterbar",
         "rust"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",


### PR DESCRIPTION
As mentioned in issue 225

[https://github.com/ix-plugin-hub/iocage-plugin-index/issues/225]

The default python has changed from 3.7 to 3.8.

I have upgraded this plugin to reference pyhton 3.8.