### PR TITLE
update pkgs for zwavejs2mqtt

### DIFF
--- a/zwavejs2mqtt.json
+++ b/zwavejs2mqtt.json
@@ -22,9 +22,11 @@
     "pkgs": [
         "bash",
         "curl",
-        "node14",
-        "npm-node14",
-        "python"
+        "jq",
+        "node",
+        "npm",
+        "python",
+        "yarn"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {
@@ -35,5 +37,5 @@
             }
         ]
     },
-    "revision": 1
+    "revision": 2
 }


### PR DESCRIPTION
Update the packages for Z-Wave JS to MQTT
 - adds `jq` and `yarn`
 - switch to current `node` version

---

<s>On a side note @fulder - I looked back at the cirrus results and the builds have been passing even though the service failed to start and the admin portal was not reachable. Should the cirrus test have caught this? If so, I think it should have been failing for a few weeks now -- Or will it pass because the jail itself is successful and running?

https://github.com/tprelog/iocage-zwavejs2mqtt/issues/1</s>

Sorry @fulder, it looks like we are only running cirrus on a plug request (and merge)? I had myself confused with this issue #194 - I thought we were already running the periodic cirrus test, but now I realize this is not correct.

---

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task