### PR TITLE
Update for newest version of Sickchill that uses virtualenv

### DIFF
--- a/sickchill.json
+++ b/sickchill.json
@@ -10,10 +10,14 @@
         "py38-setuptools",
         "py38-sqlite3",
         "py38-pillow",
+        "py38-cryptography",
+        "py38-virtualenv",
         "unrar",
         "ca_root_nss",
         "libmediainfo",
-        "libxslt"
+        "libxslt",
+        "libxml2",
+        "rust"
     ],
     "properties": {
         "nat": 1,

--- a/sickchill.json
+++ b/sickchill.json
@@ -10,7 +10,6 @@
         "py38-setuptools",
         "py38-sqlite3",
         "py38-pillow",
-        "py38-cryptography",
         "py38-virtualenv",
         "unrar",
         "ca_root_nss",


### PR DESCRIPTION
This just adds the dependencies that are required for the newest version of Sickchill that uses virtualenv. Rust is needed to compile the python cryptography module since the wheel is not available.

Goes with https://github.com/ix-plugin-hub/iocage-plugin-sickchill/pull/2

Discussion: https://github.com/SickChill/SickChill/issues/7253