### PR TITLE
[node-red] bump node from 10.x to 14.x

### DIFF
--- a/node-red.json
+++ b/node-red.json
@@ -10,8 +10,8 @@
     "pkgs": [
         "bash",
         "gmake",
-        "node10",
-        "npm-node10",
+        "node14",
+        "npm-node14",
         "python27",
         "python"
     ],


### PR DESCRIPTION
Dear maintainers,

first of all, thank you for your effort. 💪 

It's my first PR to the repository so I'm open for suggestions.

because @tprelog stopped maintaining `node-red` plugin I'd like to bump some deps because node10 is no more available. 

In accordance to [node-red's documentation](https://nodered.org/docs/faq/node-versions) node v14 is supported.

Shall I open a new PR for `master` branch? What's the branching model & merge strategy available here? 
