### PR TITLE
[node-red] bump node from 10.x to 14.x (master)

### DIFF
--- a/node-red.json
+++ b/node-red.json
@@ -10,8 +10,8 @@
     "pkgs": [
         "bash",
         "gmake",
-        "node10",
-        "npm-node10",
+        "node14",
+        "npm-node14",
         "python27",
         "python"
     ],


### PR DESCRIPTION
More details can be found here: https://github.com/ix-plugin-hub/iocage-plugin-index/pull/253#issue-696862398

This PR includes cherry-picked commit from `partikus:12.2-RELEASE`

Initial PR: https://github.com/ix-plugin-hub/iocage-plugin-index/pull/253