### PR TITLE
Change bazarr git package to unzip

### DIFF
--- a/bazarr.json
+++ b/bazarr.json
@@ -9,7 +9,7 @@
         "py38-libxml2",
         "py38-sqlite3",
         "libxslt",
-        "git-lite",
+        "unzip",
         "unrar",
         "ffmpeg"
     ],


### PR DESCRIPTION
Part of fixes for the new comment in closed issue: https://github.com/ix-plugin-hub/iocage-plugin-index/issues/230#issuecomment-893853534

Bazarr has changed the update mechanism from git to zip archive and the recommended FreeBSD installation is to use this new archive rather than just clone the bazarr repo. See related comment in: https://github.com/morpheus65535/bazarr/issues/1476 

I've already merged a possible fix for the issues in: https://github.com/fulder/iocage-plugin-bazarr/pull/9 so would be nice to get this merge as well soon :)

-------
Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task