### PR TITLE
update ESPHome pkgs list

### DIFF
--- a/esphome.json
+++ b/esphome.json
@@ -11,13 +11,13 @@
         "autoconf",
         "bash",
         "ca_root_nss",
-        "curl",
         "gcc",
         "gmake",
+        "hash",
         "pkgconf",
-        "python3",
         "python38",
-        "py38-pillow"
+        "py38-pillow",
+        "rust"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
I gave the ESPHome plugin some much needed attention. Please merge these changes to the 12.2-RELEASE branch ASAP.

This adds a few new dependencies and removes some that are no longer needed

- issue #261