### PR TITLE
Remove commented out crypto related cirrus-ci tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,16 +55,6 @@ channels-dvr_task:
   env:
     PLUGIN_FILE: "channels-dvr.json"
 
-# Disabled due to Cirrus-CI automatic crypto mining suspension mechanism
-#chia_task:
-#  <<: *INSTALL_PLUGIN
-#  only_if: "changesInclude('chia.json', '.cirrus/install_script.sh')"
-#  matrix:
-#    - freebsd_instance:
-#        image_family: freebsd-12-2
-#  env:
-#    PLUGIN_FILE: "chia.json"
-
 clamav_task:
   <<: *INSTALL_PLUGIN
   only_if: "changesInclude('clamav.json', '.cirrus/install_script.sh')"
@@ -591,16 +581,6 @@ weechat_task:
         image_family: freebsd-12-2
   env:
     PLUGIN_FILE: "weechat.json"
-
-# Disabled due to Cirrus-CI automatic crypto mining suspension mechanism
-#xmrig_task:
-#  <<: *INSTALL_PLUGIN
-#  only_if: "changesInclude('xmrig.json', '.cirrus/install_script.sh')"
-#  matrix:
-#    - freebsd_instance:
-#        image_family: freebsd-12-2
-#  env:
-#    PLUGIN_FILE: "xmrig.json"
     
 zabbixserver_task:
   <<: *INSTALL_PLUGIN


### PR DESCRIPTION
Even though the crypto related cirrus-ci tasks where commented out, the Cirrus-CI blocking mechanism seems to be sensitive and still block out repositories (due to finding the, commented out, `xmrig` inside the config file).

I've removed them entirely from the `.cirrus.tml`  file. Hopefully (:crossed_fingers:) this will help with the automatic block in a better way (at least my fork `master` run is still in progress right now: https://github.com/fulder/iocage-plugin-index/runs/3646145674)

----

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task