### PR TITLE
Update Grafana to v8

### DIFF
--- a/grafana.json
+++ b/grafana.json
@@ -3,7 +3,7 @@
     "release": "12.2-RELEASE",
     "artifact": "https://github.com/MalteHillmann/iocage-plugin-grafana.git",
     "pkgs": [
-        "grafana7",
+        "grafana8",
         "influxdb",
         "curl"
     ],


### PR DESCRIPTION
Update Grafana to version 8, which is the latest and greatest Grafana:
https://www.freshports.org/www/grafana8/