### PR TITLE
Install only python27 package in motioneye

### DIFF
--- a/motioneye.json
+++ b/motioneye.json
@@ -8,8 +8,7 @@
         "nat_forwards": "tcp(8765:8765)"
     },
     "pkgs": [
-        "python37",
-        "py37-pip",
+        "python27",
         "motion",
         "ffmpeg",
         "v4l-utils",


### PR DESCRIPTION
This is a duplicate of: https://github.com/ix-plugin-hub/iocage-plugin-index/pull/188 as it seems to have gotten a bit stale since 12th of March, so can probably be closed if this gets merged instead.

Closes: https://github.com/ix-plugin-hub/iocage-plugin-index/pull/188

The cirrus tests looks green and I've tried to manually install the plugin from this branch, looks like it still works

-----

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task