### PR TITLE
add allow_mlock to support dotnet for radarr

### DIFF
--- a/radarr.json
+++ b/radarr.json
@@ -4,7 +4,7 @@
     "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
     "official": false,
     "properties": {
-        "allow_mlock": "1",
+        "allow_mlock": 1,
         "nat": 1,
         "nat_forwards": "tcp(7878:7878)"
     },

--- a/radarr.json
+++ b/radarr.json
@@ -4,6 +4,7 @@
     "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
     "official": false,
     "properties": {
+		"allow_mlock": "1"
         "nat": 1,
         "nat_forwards": "tcp(7878:7878)"
     },

--- a/radarr.json
+++ b/radarr.json
@@ -4,7 +4,7 @@
     "artifact": "https://github.com/freenas/iocage-plugin-radarr.git",
     "official": false,
     "properties": {
-		"allow_mlock": "1"
+        "allow_mlock": "1",
         "nat": 1,
         "nat_forwards": "tcp(7878:7878)"
     },


### PR DESCRIPTION
dotNET under FreeBSD needs to use `mlock(2)` and the current community plugin does not add this during jail creation.

This PR corrects it by adding `"allow_mlock": "1"`  into the json used by plugin system during creation