### PR TITLE
Fix INDEX Formatting

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -378,15 +378,15 @@
 		"name": "Netdata",
 		"official": false
 	},
-    "nexus-oss": {
-        "MANIFEST": "nexus-oss.json",
-        "name": "NexusOSS",
-        "icon": "https://icons.freenas.org/community-icons/nexus-oss.png",
-        "description": "Nexus OSS Repository Manager",
-        "maintainer": "Filippe Spolti <filippespolti@gmail.com>",
-        "official": false,
-        "primary_pkg": null
-    },
+    	"nexus-oss": {
+        	"MANIFEST": "nexus-oss.json",
+        	"name": "NexusOSS",
+        	"icon": "https://icons.freenas.org/community-icons/nexus-oss.png",
+        	"description": "Nexus OSS Repository Manager",
+        	"maintainer": "Filippe Spolti <filippespolti@gmail.com>",
+        	"official": false,
+        	"primary_pkg": null
+    	},
 	"node-red": {
 		"MANIFEST": "node-red.json",
 		"description": "Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways.",


### PR DESCRIPTION
Fix NexusOSS formatting
Remove extra line

There is something wrong with the INDEX file as far as I can tell starting with line 381, these edits "seem" to fix it. When editing there is also an extra line at the bottom, I tried deleting it but I think it's still there. Should line 659 be `},`? 

If this is a waste of time just reject and close, I was just looking for a reason why my TrueNAS box hasn't pulled down the last four plugin updates and thought this might have something to do with it.