### PR TITLE
Update Heimdall-dashboard to PHP 8.0

### DIFF
--- a/INDEX
+++ b/INDEX
@@ -196,7 +196,8 @@
 		"icon": "https://icons.freenas.org/community-icons/heimdall-dashboard.png",
 		"name": "Heimdall",
 		"official": false,
-		"primary_pkg": null
+		"primary_pkg": null,
+		"homepage": "https://heimdall.site/"
 	},
 	"homeassistant": {
 		"MANIFEST": "homeassistant.json",

--- a/heimdall-dashboard.json
+++ b/heimdall-dashboard.json
@@ -6,21 +6,18 @@
         "dhcp": "1"
     },
     "pkgs": [
-        "git-lite",
+        "git-tiny",
         "nginx",
-        "php73",
-        "php73-ctype",
-        "php73-filter",
-        "php73-hash",
-        "php73-json",
-        "php73-mbstring",
-        "php73-openssl",
-        "php73-pdo_sqlite",
-        "php73-session",
-        "php73-sqlite3",
-        "php73-tokenizer",
-        "php73-xml",
-        "php73-zip"
+        "php80",
+        "php80-ctype",
+        "php80-filter",
+        "php80-mbstring",
+        "php80-pdo_sqlite",
+        "php80-session",
+        "php80-sqlite3",
+        "php80-tokenizer",
+        "php80-xml",
+        "php80-zip"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
This updates the Heimdall Dashboard plugin to PHP 8.0