### PR TITLE
Update MineOS to Python 3.9 & FreeBSD 12.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -335,7 +335,7 @@ mineos_task:
   only_if: "changesInclude('mineos.json', '.cirrus/install_script.sh')"
   matrix:
     - freebsd_instance:
-        image_family: freebsd-12-2
+        image_family: freebsd-12-3
   env:
     PLUGIN_FILE: "mineos.json"
 

--- a/mineos.json
+++ b/mineos.json
@@ -1,6 +1,6 @@
 {
     "name": "mineos",
-    "release": "12.2-RELEASE",
+    "release": "12.3-RELEASE",
     "artifact": "https://github.com/jsegaert/iocage-plugin-mineos.git",
     "official": false,
     "properties": {
@@ -11,12 +11,12 @@
         "nat_forwards": "tcp(8443:8443),tcp(25565:25565),tcp(25566:25566),tcp(25567:25567),tcp(25568:25568),tcp(25569:25569),tcp(25570:25570)"
     },
     "pkgs": [
-        "py38-rdiff-backup",
+        "py39-rdiff-backup",
         "screen",
         "rsync",
         "gmake",
         "git-lite",
-        "python38",
+        "python39",
         "node",
         "npm",
         "openjdk17",


### PR DESCRIPTION
This PR makes the following updates to the MineOS plugin

- Update Python packages from 3.8 to 3.9
- Update FreeBSD version from 12.2 to 12.3

Thank you!
