### PR TITLE
Getting 13.1 up for Calibre-Web

### DIFF
--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,15 +1,15 @@
 {
     "name": "Calibre-Web",
-    "release": "12.2-RELEASE",
+    "release": "13.1-RELEASE",
     "artifact": "https://github.com/aserrallerios/iocage-plugin-calibre-web.git",
     "pkgs": [
         "git",
         "python3",
-        "python38",
-        "py38-pip",
-        "py38-setuptools",
-        "py38-sqlite3",
-        "py38-ldap",
+        "python39",
+        "py39-pip",
+        "py39-setuptools",
+        "py39-sqlite3",
+        "py39-ldap",
         "rust",
         "calibre",
         "unrar",
@@ -29,5 +29,5 @@
         ]
     },
     "official": false,
-    "revision": 0
+    "revision": 131
 }


### PR DESCRIPTION
Attempt 1. Per several places but https://www.reddit.com/r/truenas/comments/vyxnzb/difficulties_with_calibreweb/ for a single example need to update to py39 for 13.1

I've installed and verified that the plug-in completes from this .json when performed locally via iocage fetch of this json