### PR TITLE
Fix Motioneye Plugin Python Usage

### DIFF
--- a/motioneye.json
+++ b/motioneye.json
@@ -25,5 +25,5 @@
             }
         ]
     },
-    "revision": "2"
+    "revision": 2
 }

--- a/motioneye.json
+++ b/motioneye.json
@@ -1,7 +1,8 @@
 {
     "name": "motioneye",
+    "plugin_schema": "2",
     "release": "13.1-RELEASE",
-    "artifact": "https://github.com/cilix-lab/iocage-plugin-motioneye.git",
+    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
     "official": false,
     "properties": {
         "nat": 1,
@@ -24,5 +25,5 @@
             }
         ]
     },
-    "revision": 1
+    "revision": "2"
 }


### PR DESCRIPTION
This fixes the artefact for the motioneye plugin to remove fixed call of python 2.3 and made it use newest Python 2.7 but this is only start of moving to Python 3 now that motion package is moving forward again.