### PR TITLE
Python3 update of MotionEye

### DIFF
--- a/motioneye.json
+++ b/motioneye.json
@@ -10,6 +10,7 @@
         "nat_forwards": "tcp(8765:8765)"
     },
     "pkgs": [
+        "bash",
         "curl",
         "python3",
         "python39",

--- a/motioneye.json
+++ b/motioneye.json
@@ -1,7 +1,7 @@
 {
     "name": "motioneye",
     "plugin_schema": "2",
-    "release": "Python3",
+    "release": "python3",
     "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
     "official": false,
     "properties": {

--- a/motioneye.json
+++ b/motioneye.json
@@ -3,7 +3,7 @@
     "plugin_schema": "2",
     "release": "13.1-RELEASE",
     "branch": "python3",
-    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye-python3.git",
+    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
     "official": false,
     "properties": {
         "nat": 1,

--- a/motioneye.json
+++ b/motioneye.json
@@ -2,8 +2,7 @@
     "name": "motioneye",
     "plugin_schema": "2",
     "release": "13.1-RELEASE",
-    "branch": "python3",
-    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
+    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye-python3.git",
     "official": false,
     "properties": {
         "nat": 1,

--- a/motioneye.json
+++ b/motioneye.json
@@ -3,7 +3,7 @@
     "plugin_schema": "2",
     "release": "13.1-RELEASE",
     "branch": "python3",
-    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
+    "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye-python3.git",
     "official": false,
     "properties": {
         "nat": 1,

--- a/motioneye.json
+++ b/motioneye.json
@@ -12,7 +12,7 @@
     "pkgs": [
         "curl",
         "python3",
-        "python311",
+        "python39",
         "gcc",
         "motion",
         "ffmpeg",

--- a/motioneye.json
+++ b/motioneye.json
@@ -29,5 +29,5 @@
             }
         ]
     },
-    "revision": 2
+    "revision": 3
 }

--- a/motioneye.json
+++ b/motioneye.json
@@ -1,7 +1,8 @@
 {
     "name": "motioneye",
     "plugin_schema": "2",
-    "release": "python3",
+    "release": "13.1-RELEASE",
+    "branch": "python3",
     "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
     "official": false,
     "properties": {

--- a/motioneye.json
+++ b/motioneye.json
@@ -9,12 +9,14 @@
         "nat_forwards": "tcp(8765:8765)"
     },
     "pkgs": [
-        "python27",
+        "curl",
+        "python3",
+        "python311",
+        "gcc",
         "motion",
         "ffmpeg",
         "v4l-utils",
-        "jpeg-turbo",
-        "curl"
+        "jpeg-turbo"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {

--- a/motioneye.json
+++ b/motioneye.json
@@ -1,7 +1,7 @@
 {
     "name": "motioneye",
     "plugin_schema": "2",
-    "release": "13.1-RELEASE",
+    "release": "Python3",
     "artifact": "https://github.com/Baenwort/iocage-plugin-motioneye.git",
     "official": false,
     "properties": {


### PR DESCRIPTION
This is the initial release of getting the MotionEye plug-in to use Python 3 (still in support) instead of Python 2.7 (past EOL) by moving to the dev branch of motioneye. 

This should be temporary until the .43 release of motioneye when I can switch back to the main branch.

I am also switching the artefact to a temp repo to facilitate so that there isn't any period of time after this PR is merged, but before I can update the main repo, that things won't work. Once this PR is accepted I will update the main artefact repo and then issue a PR to update the manifest.json to point back at it.

This is due to the 'branch' variable of iocage fetch not being supported in the manifest system. Maybe some day [this](https://github.com/iocage/iocage/pull/1248) PR will be accepted and the manifest system will acknowledge the branch variable that currently works with iocage due to the hard work of the FreeBSD port maintainer.  