### PR TITLE
Use elasticsearch7 in graylog plugin

### DIFF
--- a/graylog.json
+++ b/graylog.json
@@ -9,7 +9,7 @@
     "pkgs": [
         "graylog",
         "elasticsearch7",
-        "mongodb44",
+        "mongodb50",
         "pwgen",
         "p5-Digest-SHA"
     ],

--- a/graylog.json
+++ b/graylog.json
@@ -8,7 +8,7 @@
     },
     "pkgs": [
         "graylog",
-        "elasticsearch6",
+        "elasticsearch7",
         "mongodb44",
         "pwgen",
         "p5-Digest-SHA"


### PR DESCRIPTION
The elasticsearch6 port has been deprecated and removed from the ports tree, this causes installation of this plugin to fail with 13.1. With this change we use elasticsearch7 instead

See: https://github.com/FreeBSD/freebsd-ports/commit/dc721d84ea9ad5e97d2c518b2bdca0fd37a4382b