### PR TITLE
fix famp install issue

### DIFF
--- a/famp.json
+++ b/famp.json
@@ -5,9 +5,9 @@
     "pkgs": [
         "apache24",
         "mysql80-server",
-        "php74",
-        "php74-mysqli",
-        "mod_php74"
+        "php80",
+        "php80-mysqli",
+        "mod_php80"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
fix the following issue 
Error: FAMP had a failure Exception: RuntimeError Message: pkg error: - php74 :,php74-mysqli :,mod_php74 : Refusing to fetch artifact and run post_install.sh! Partial plugin destroyed

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task