### PR TITLE
Remove transmission-web

### DIFF
--- a/transmission.json
+++ b/transmission.json
@@ -8,8 +8,7 @@
         "nat_forwards": "tcp(9091:9091)"
     },
     "pkgs": [
-        "transmission-daemon",
-        "transmission-web"
+        "transmission-daemon"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Transmission has been updated to 4.0.4 and as such transmission-web has been included in the transmission-daemon package so is no longer needed and the update fails otherwise.