### PR TITLE
Change grafana8 to grafana9

### DIFF
--- a/grafana.json
+++ b/grafana.json
@@ -3,7 +3,7 @@
     "release": "13.1-RELEASE",
     "artifact": "https://github.com/MalteHillmann/iocage-plugin-grafana.git",
     "pkgs": [
-        "grafana8",
+        "grafana9",
         "influxdb",
         "collectd5",
         "curl"


### PR DESCRIPTION
One tiny change needed for the grafana plugin to install:

- update grafana8 to grafana9 to reflect reality in repository