### PR TITLE
Update calibre-web.json

### DIFF
--- a/calibre-web.json
+++ b/calibre-web.json
@@ -9,7 +9,7 @@
         "py39-pip",
         "py39-setuptools",
         "py39-sqlite3",
-        "py39-ldap",
+        "py39-python-ldap",
         "rust",
         "calibre",
         "unrar",


### PR DESCRIPTION
py39-ldap is removed from Freshports and now we should use py39-python-ldap https://www.freshports.org/net/py-ldap/ see 3.4.3 change
