### PR TITLE
Update guacamole.json

### DIFF
--- a/guacamole.json
+++ b/guacamole.json
@@ -7,7 +7,7 @@
         "guacamole-server",
         "guacamole-client",
         "mysql80-server",
-        "mysql-connector-java"
+        "mysql-connector-j"
     ],
     "properties": {
         "nat": 1,


### PR DESCRIPTION
fix to match https://github.com/leandroscardua/iocage-plugin-guacamole/blob/master/guacamole.json

now using mysql-connector-j instead of mysql-connector-java. without fix, plugin fails to install 

Thank you for your submission to the FreeNAS community plugins repository!

Please ensure the following guidelines are met when submitting a new Plugin.

1. Add the entry to INDEX in alphabetical order
2. Includes a new icon in the ./icon/ directory
3. Ensure the submitted icon file is a valid PNG that is 128x128 in size
4. Add new plugin cirrus task