### PR TITLE
Update Python to 3.11

### DIFF
--- a/tautulli.json
+++ b/tautulli.json
@@ -5,8 +5,8 @@
     "official": false,
     "pkgs": [
         "lang/python",
-        "py39-sqlite3",
-        "py39-openssl",
+        "py311-sqlite3",
+        "py311-openssl",
         "security/ca_root_nss",
         "git"
     ],


### PR DESCRIPTION
Default python version changed to 3.11. Plugin installation fails with the following error:
<img width="401" alt="image" src="https://github.com/ix-plugin-hub/iocage-plugin-index/assets/7771817/d6aeaa1f-7afc-42ab-903e-bd3609090748">
