### PR TITLE
Update jellyfin.json to 13.3-RELEASE

### DIFF
--- a/jellyfin.json
+++ b/jellyfin.json
@@ -1,6 +1,6 @@
 {
     "name": "Jellyfin Server",
-    "release": "13.2-RELEASE",
+    "release": "13.3-RELEASE",
     "artifact": "https://github.com/spz2k9/iocage-plugin-jellyfin.git",
     "official": false,
     "properties": {
@@ -34,5 +34,5 @@
             }
         ]
     },
-    "revision": 3
+    "revision": 5
 }


### PR DESCRIPTION
To match the contents of https://github.com/spz2k9/iocage-plugin-jellyfin/pull/12

For the same reason as stated in that PR: the port of jellyfin doesn't work except on 13.3 or 14+. Obviously you will need to have manually installed TrueNAS 13.3 for this to work, but this plugin doesn't work on TrueNAS 13.0 as-is anyway. Before TrueNAS CORE goes the way of the dodo, it'd be nice for this plugin to work.